### PR TITLE
Support GHC 8.4

### DIFF
--- a/context-http-client/context-http-client.cabal
+++ b/context-http-client/context-http-client.cabal
@@ -37,7 +37,7 @@ library
       library
   ghc-options: -Wall -fwarn-tabs -Wincomplete-uni-patterns -Wredundant-constraints
   build-depends:
-      base >=4.12 && <5
+      base >=4.11.1.0 && <5
     , context >=0.2.0.0 && <0.3
     , http-client >=0.5.13.1 && <0.8
   default-language: Haskell2010

--- a/context-http-client/package.yaml
+++ b/context-http-client/package.yaml
@@ -25,7 +25,7 @@ ghc-options:
 
 library:
   dependencies:
-  - base >=4.12 && <5
+  - base >=4.11.1.0 && <5
   - context >=0.2.0.0 && <0.3
   - http-client >=0.5.13.1 && <0.8
   source-dirs: library

--- a/context-resource/context-resource.cabal
+++ b/context-resource/context-resource.cabal
@@ -38,7 +38,7 @@ library
       library
   ghc-options: -Wall -fwarn-tabs -Wincomplete-uni-patterns -Wredundant-constraints
   build-depends:
-      base >=4.12 && <5
+      base >=4.11.1.0 && <5
     , context >=0.2.0.0 && <0.3
     , exceptions >=0.10.0 && <0.11
   default-language: Haskell2010

--- a/context-resource/library/Context/Resource.hs
+++ b/context-resource/library/Context/Resource.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NoImplicitPrelude #-}
@@ -47,7 +46,7 @@ withProvider
   -> (Provider m res -> m a)
   -> m a
 withProvider withRes f = do
-  Context.withStore Context.noPropagation (Just (WithRes withRes)) \store -> do
+  Context.withStore Context.noPropagation (Just (WithRes withRes)) $ \store -> do
     f Provider { store }
 
 -- | Acquire a resource from the specified 'Provider', for the duration of the
@@ -93,8 +92,8 @@ withSharedResource
   -> (res -> m a)
   -> m a
 withSharedResource provider f = do
-  withResource provider \resource -> do
-    shareResource provider resource do
+  withResource provider $ \resource -> do
+    shareResource provider resource $ do
       f resource
 
 -- $intro

--- a/context-resource/package.yaml
+++ b/context-resource/package.yaml
@@ -26,7 +26,7 @@ ghc-options:
 
 library:
   dependencies:
-  - base >=4.12 && <5
+  - base >=4.11.1.0 && <5
   - context >=0.2.0.0 && <0.3
   - exceptions >=0.10.0 && <0.11
   source-dirs: library

--- a/context-resource/test-suite/Test/Context/ResourceSpec.hs
+++ b/context-resource/test-suite/Test/Context/ResourceSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Test.Context.ResourceSpec
@@ -16,65 +15,65 @@ import qualified Foreign
 
 spec :: Spec
 spec = do
-  describe "withResource" do
-    it "concurrent test" do
-      Async.forConcurrently_ [1 :: Int ..10] $ const do
-        withProvider withRes \provider -> do
-          withResource provider \ptr1 -> do
-            withResource provider \ptr2 -> do
+  describe "withResource" $ do
+    it "concurrent test" $ do
+      Async.forConcurrently_ [1 :: Int ..10] $ const $ do
+        withProvider withRes $ \provider -> do
+          withResource provider $ \ptr1 -> do
+            withResource provider $ \ptr2 -> do
               ptr1 `shouldNotBe` ptr2
 
-  describe "shareResource" do
-    it "concurrent test" do
-      Async.forConcurrently_ [1 :: Int ..10] $ const do
-        withProvider withRes \provider -> do
-          withResource provider \ptr1 -> do
-            shareResource provider ptr1 do
-              withResource provider \ptr2 -> do
+  describe "shareResource" $ do
+    it "concurrent test" $ do
+      Async.forConcurrently_ [1 :: Int ..10] $ const $ do
+        withProvider withRes $ \provider -> do
+          withResource provider $ \ptr1 -> do
+            shareResource provider ptr1 $ do
+              withResource provider $ \ptr2 -> do
                 ptr1 `shouldBe` ptr2
-                withResource provider \ptr3 -> do
+                withResource provider $ \ptr3 -> do
                   ptr2 `shouldBe` ptr3
-            withResource provider \ptr4 -> do
+            withResource provider $ \ptr4 -> do
               ptr1 `shouldNotBe` ptr4
-    it "cannot implicitly share across thread boundaries" do
-      withProvider withRes \provider -> do
-        withResource provider \parentThread'sPtr1 -> do
-          shareResource provider parentThread'sPtr1 do
-            withResource provider \parentThread'sPtr2 -> do
+    it "cannot implicitly share across thread boundaries" $ do
+      withProvider withRes $ \provider -> do
+        withResource provider $ \parentThread'sPtr1 -> do
+          shareResource provider parentThread'sPtr1 $ do
+            withResource provider $ \parentThread'sPtr2 -> do
               parentThread'sPtr1 `shouldBe` parentThread'sPtr2
             threadDone <- Context.newEmptyMVar
-            Monad.void $ Context.forkIO do
-              withResource provider \childThread'sPtr1 -> do
+            Monad.void $ Context.forkIO $ do
+              withResource provider $ \childThread'sPtr1 -> do
                 parentThread'sPtr1 `shouldNotBe` childThread'sPtr1
               Context.putMVar threadDone ()
             Context.takeMVar threadDone
-          withResource provider \parentThread'sPtr3 -> do
+          withResource provider $ \parentThread'sPtr3 -> do
             parentThread'sPtr1 `shouldNotBe` parentThread'sPtr3
 
-  describe "withSharedResource" do
-    it "concurrent test" do
-      Async.forConcurrently_ [1 :: Int ..10] $ const do
-        withProvider withRes \provider -> do
-          withSharedResource provider \ptr1 -> do
-            withResource provider \ptr2 -> do
+  describe "withSharedResource" $ do
+    it "concurrent test" $ do
+      Async.forConcurrently_ [1 :: Int ..10] $ const $ do
+        withProvider withRes $ \provider -> do
+          withSharedResource provider $ \ptr1 -> do
+            withResource provider $ \ptr2 -> do
               ptr1 `shouldBe` ptr2
-              shareResource provider ptr2 do
-                withResource provider \ptr3 -> do
+              shareResource provider ptr2 $ do
+                withResource provider $ \ptr3 -> do
                   ptr2 `shouldBe` ptr3
-            withResource provider \ptr4 -> do
+            withResource provider $ \ptr4 -> do
               ptr1 `shouldBe` ptr4
-    it "cannot implicitly share across thread boundaries" do
-      withProvider withRes \provider -> do
-        withSharedResource provider \parentThread'sPtr1 -> do
-          withResource provider \parentThread'sPtr2 -> do
+    it "cannot implicitly share across thread boundaries" $ do
+      withProvider withRes $ \provider -> do
+        withSharedResource provider $ \parentThread'sPtr1 -> do
+          withResource provider $ \parentThread'sPtr2 -> do
             parentThread'sPtr1 `shouldBe` parentThread'sPtr2
           threadDone <- Context.newEmptyMVar
-          Monad.void $ Context.forkIO do
-            withResource provider \childThread'sPtr1 -> do
+          Monad.void $ Context.forkIO $ do
+            withResource provider $ \childThread'sPtr1 -> do
               parentThread'sPtr1 `shouldNotBe` childThread'sPtr1
             Context.putMVar threadDone ()
           Context.takeMVar threadDone
-          withResource provider \parentThread'sPtr3 -> do
+          withResource provider $ \parentThread'sPtr3 -> do
             parentThread'sPtr1 `shouldBe` parentThread'sPtr3
 
 withRes :: (Ptr Int -> IO a) -> IO a

--- a/context-wai-middleware/context-wai-middleware.cabal
+++ b/context-wai-middleware/context-wai-middleware.cabal
@@ -37,7 +37,7 @@ library
       library
   ghc-options: -Wall -fwarn-tabs -Wincomplete-uni-patterns -Wredundant-constraints
   build-depends:
-      base >=4.12 && <5
+      base >=4.11.1.0 && <5
     , context >=0.2.0.0 && <0.3
     , wai >=3.0.3.0 && <3.3
   default-language: Haskell2010

--- a/context-wai-middleware/library/Network/Wai/Middleware/Context.hs
+++ b/context-wai-middleware/library/Network/Wai/Middleware/Context.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
@@ -32,7 +31,7 @@ addRequestContext
   -> Wai.Middleware
 addRequestContext contextStore mkContext app = \request sendResponse -> do
   context <- mkContext request
-  Context.use contextStore context do
+  Context.use contextStore context $ do
     app request sendResponse
 
 -- | Register request-specific context into the provided 'Context.Store', for
@@ -53,7 +52,7 @@ addRequestContextMay contextStore mkContext app = \request sendResponse -> do
   mkContext request >>= \case
     Nothing -> app request sendResponse
     Just context ->
-      Context.use contextStore context do
+      Context.use contextStore context $ do
         app request sendResponse
 
 -- | Register arbitrary context into the provided 'Context.Store', for
@@ -69,5 +68,5 @@ addRequestContextMay contextStore mkContext app = \request sendResponse -> do
 addContext :: Context.Store ctx -> IO ctx -> Wai.Middleware
 addContext contextStore mkContext app = \request sendResponse -> do
   context <- mkContext
-  Context.use contextStore context do
+  Context.use contextStore context $ do
     app request sendResponse

--- a/context-wai-middleware/package.yaml
+++ b/context-wai-middleware/package.yaml
@@ -25,7 +25,7 @@ ghc-options:
 
 library:
   dependencies:
-  - base >=4.12 && <5
+  - base >=4.11.1.0 && <5
   - context >=0.2.0.0 && <0.3
   - wai >=3.0.3.0 && <3.3
   source-dirs: library

--- a/context/context.cabal
+++ b/context/context.cabal
@@ -43,8 +43,8 @@ library
       library
   ghc-options: -Wall -fwarn-tabs -Wincomplete-uni-patterns -Wredundant-constraints
   build-depends:
-      base >=4.12 && <5
-    , containers >=0.6.0.1 && <0.7
+      base >=4.11.1.0 && <5
+    , containers >=0.5.11.0 && <0.7
     , exceptions >=0.10.0 && <0.11
   default-language: Haskell2010
 

--- a/context/library/Context/Concurrent.hs
+++ b/context/library/Context/Concurrent.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE RankNTypes #-}
 
@@ -60,7 +59,7 @@ import qualified Control.Exception as Exception
 -- @since 0.1.0.0
 forkIO :: IO () -> IO ThreadId
 forkIO action = do
-  Internal.withPropagator \propagate -> do
+  Internal.withPropagator $ \propagate -> do
     Concurrent.forkIO $ propagate action
 
 -- | See 'Concurrent.forkFinally'.
@@ -72,9 +71,9 @@ forkFinally action and_then = do
   -- Control.Concurrent function. This enables us to propagate context a single
   -- time to make it available to both the thread's main action and terminating
   -- action.
-  Internal.withPropagator \propagate -> do
-    Exception.mask \restore -> do
-      Concurrent.forkIO $ propagate do
+  Internal.withPropagator $ \propagate -> do
+    Exception.mask $ \restore -> do
+      Concurrent.forkIO $ propagate $ do
         Exception.try (restore action) >>= and_then
 
 -- | See 'Concurrent.forkIOWithUnmask'.
@@ -82,8 +81,8 @@ forkFinally action and_then = do
 -- @since 0.1.0.0
 forkIOWithUnmask :: ((forall a. IO a -> IO a) -> IO ()) -> IO ThreadId
 forkIOWithUnmask io = do
-  Internal.withPropagator \propagate -> do
-    Concurrent.forkIOWithUnmask \restore -> do
+  Internal.withPropagator $ \propagate -> do
+    Concurrent.forkIOWithUnmask $ \restore -> do
       propagate $ io restore
 
 -- | See 'Concurrent.forkOn'.
@@ -91,7 +90,7 @@ forkIOWithUnmask io = do
 -- @since 0.1.0.0
 forkOn :: Int -> IO () -> IO ThreadId
 forkOn cpu action = do
-  Internal.withPropagator \propagate -> do
+  Internal.withPropagator $ \propagate -> do
     Concurrent.forkOn cpu $ propagate action
 
 -- | See 'Concurrent.forkOnWithUnmask'.
@@ -99,8 +98,8 @@ forkOn cpu action = do
 -- @since 0.1.0.0
 forkOnWithUnmask :: Int -> ((forall a. IO a -> IO a) -> IO ()) -> IO ThreadId
 forkOnWithUnmask cpu io = do
-  Internal.withPropagator \propagate -> do
-    Concurrent.forkOnWithUnmask cpu \restore -> do
+  Internal.withPropagator $ \propagate -> do
+    Concurrent.forkOnWithUnmask cpu $ \restore -> do
       propagate $ io restore
 
 -- | See 'Concurrent.forkOS'.
@@ -108,7 +107,7 @@ forkOnWithUnmask cpu io = do
 -- @since 0.1.0.0
 forkOS :: IO () -> IO ThreadId
 forkOS action = do
-  Internal.withPropagator \propagate -> do
+  Internal.withPropagator $ \propagate -> do
     Concurrent.forkOS $ propagate action
 
 -- | See 'Concurrent.forkOSWithUnmask'.
@@ -116,8 +115,8 @@ forkOS action = do
 -- @since 0.1.0.0
 forkOSWithUnmask :: ((forall a. IO a -> IO a) -> IO ()) -> IO ThreadId
 forkOSWithUnmask io = do
-  Internal.withPropagator \propagate -> do
-    Concurrent.forkOSWithUnmask \restore -> do
+  Internal.withPropagator $ \propagate -> do
+    Concurrent.forkOSWithUnmask $ \restore -> do
       propagate $ io restore
 
 -- | See 'Concurrent.runInBoundThread'.
@@ -125,7 +124,7 @@ forkOSWithUnmask io = do
 -- @since 0.1.0.0
 runInBoundThread :: IO a -> IO a
 runInBoundThread action =
-  Internal.withPropagator \propagate -> do
+  Internal.withPropagator $ \propagate -> do
     Concurrent.runInBoundThread $ propagate action
 
 -- | See 'Concurrent.runInUnboundThread'.
@@ -133,7 +132,7 @@ runInBoundThread action =
 -- @since 0.1.0.0
 runInUnboundThread :: IO a -> IO a
 runInUnboundThread action =
-  Internal.withPropagator \propagate -> do
+  Internal.withPropagator $ \propagate -> do
     Concurrent.runInUnboundThread $ propagate action
 
 -- $intro

--- a/context/package.yaml
+++ b/context/package.yaml
@@ -27,8 +27,8 @@ ghc-options:
 
 library:
   dependencies:
-  - base >=4.12 && <5
-  - containers >=0.6.0.1 && <0.7
+  - base >=4.11.1.0 && <5
+  - containers >=0.5.11.0 && <0.7
   - exceptions >=0.10.0 && <0.11
   source-dirs: library
 

--- a/context/test-suite/Test/Context/ConcurrentSpec.hs
+++ b/context/test-suite/Test/Context/ConcurrentSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NoImplicitPrelude #-}
@@ -19,414 +18,414 @@ data Thing = Thing
 
 spec :: Spec
 spec = do
-  describe "forkIO" do
-    describe "mineMay" do
-      it "empty stores" do
+  describe "forkIO" $ do
+    describe "mineMay" $ do
+      it "empty stores" $ do
         threadDone <- Context.newEmptyMVar
-        Context.withEmptyStore @IO @Thing \store1 -> do
-          Context.withEmptyStore @IO @Char \store2 -> do
-            Monad.void $ Context.forkIO do
+        Context.withEmptyStore @IO @Thing $ \store1 -> do
+          Context.withEmptyStore @IO @Char $ \store2 -> do
+            Monad.void $ Context.forkIO $ do
               Context.mineMay store1 `shouldReturn` Nothing
               Context.mineMay store2 `shouldReturn` Nothing
               Context.putMVar threadDone ()
         Context.takeMVar threadDone
-      it "initially-empty stores with registered context" do
+      it "initially-empty stores with registered context" $ do
         threadDone <- Context.newEmptyMVar
-        Context.withEmptyStore \store1 -> do
-          Context.use store1 Thing { stuff = 1 } do
-            Context.withEmptyStore \store2 -> do
-              Context.use store2 'a' do
-                Monad.void $ Context.forkIO do
+        Context.withEmptyStore $ \store1 -> do
+          Context.use store1 Thing { stuff = 1 } $ do
+            Context.withEmptyStore $ \store2 -> do
+              Context.use store2 'a' $ do
+                Monad.void $ Context.forkIO $ do
                   Context.mineMay store1 `shouldReturn` Just Thing { stuff = 1 }
                   Context.mineMay store2 `shouldReturn` Just 'a'
                   Context.putMVar threadDone ()
         Context.takeMVar threadDone
-      it "initially-empty stores with nested contexts" do
+      it "initially-empty stores with nested contexts" $ do
         threadDone <- Context.newEmptyMVar
-        Context.withEmptyStore \store1 -> do
-          Context.use store1 Thing { stuff = 1 } do
-            Context.use store1 Thing { stuff = 2 } do
-              Context.withEmptyStore \store2 -> do
-                Context.use store2 'a' do
-                  Context.use store2 'b' do
-                    Monad.void $ Context.forkIO do
+        Context.withEmptyStore $ \store1 -> do
+          Context.use store1 Thing { stuff = 1 } $ do
+            Context.use store1 Thing { stuff = 2 } $ do
+              Context.withEmptyStore $ \store2 -> do
+                Context.use store2 'a' $ do
+                  Context.use store2 'b' $ do
+                    Monad.void $ Context.forkIO $ do
                       Context.mineMay store1 `shouldReturn` Just Thing { stuff = 2 }
                       Context.mineMay store2 `shouldReturn` Just 'b'
                       Context.putMVar threadDone ()
         Context.takeMVar threadDone
-      it "non-empty stores" do
+      it "non-empty stores" $ do
         threadDone <- Context.newEmptyMVar
-        Context.withNonEmptyStore Thing { stuff = 1 } \store1 -> do
-          Context.withNonEmptyStore 'a' \store2 -> do
-            Monad.void $ Context.forkIO do
+        Context.withNonEmptyStore Thing { stuff = 1 } $ \store1 -> do
+          Context.withNonEmptyStore 'a' $ \store2 -> do
+            Monad.void $ Context.forkIO $ do
               Context.mineMay store1 `shouldReturn` Just Thing { stuff = 1 }
               Context.mineMay store2 `shouldReturn` Just 'a'
               Context.putMVar threadDone ()
         Context.takeMVar threadDone
 
-  describe "forkFinally" do
-    describe "mineMay" do
-      it "empty stores" do
+  describe "forkFinally" $ do
+    describe "mineMay" $ do
+      it "empty stores" $ do
         threadDone <- Context.newEmptyMVar
-        Context.withEmptyStore @IO @Thing \store1 -> do
-          Context.withEmptyStore @IO @Char \store2 -> do
+        Context.withEmptyStore @IO @Thing $ \store1 -> do
+          Context.withEmptyStore @IO @Char $ \store2 -> do
             let checkStores = do
                   Context.mineMay store1 `shouldReturn` Nothing
                   Context.mineMay store2 `shouldReturn` Nothing
-            Monad.void $ Context.forkFinally checkStores \_eResult -> do
+            Monad.void $ Context.forkFinally checkStores $ \_eResult -> do
               checkStores
               Context.putMVar threadDone ()
         Context.takeMVar threadDone
-      it "initially-empty stores with registered context" do
+      it "initially-empty stores with registered context" $ do
         threadDone <- Context.newEmptyMVar
-        Context.withEmptyStore \store1 -> do
-          Context.use store1 Thing { stuff = 1 } do
-            Context.withEmptyStore \store2 -> do
-              Context.use store2 'a' do
+        Context.withEmptyStore $ \store1 -> do
+          Context.use store1 Thing { stuff = 1 } $ do
+            Context.withEmptyStore $ \store2 -> do
+              Context.use store2 'a' $ do
                 let checkStores = do
                       Context.mineMay store1 `shouldReturn` Just Thing { stuff = 1 }
                       Context.mineMay store2 `shouldReturn` Just 'a'
-                Monad.void $ Context.forkFinally checkStores \_eResult -> do
+                Monad.void $ Context.forkFinally checkStores $ \_eResult -> do
                   checkStores
                   Context.putMVar threadDone ()
         Context.takeMVar threadDone
-      it "initially-empty stores with nested contexts" do
+      it "initially-empty stores with nested contexts" $ do
         threadDone <- Context.newEmptyMVar
-        Context.withEmptyStore \store1 -> do
-          Context.use store1 Thing { stuff = 1 } do
-            Context.use store1 Thing { stuff = 2 } do
-              Context.withEmptyStore \store2 -> do
-                Context.use store2 'a' do
-                  Context.use store2 'b' do
+        Context.withEmptyStore $ \store1 -> do
+          Context.use store1 Thing { stuff = 1 } $ do
+            Context.use store1 Thing { stuff = 2 } $ do
+              Context.withEmptyStore $ \store2 -> do
+                Context.use store2 'a' $ do
+                  Context.use store2 'b' $ do
                     let checkStores = do
                           Context.mineMay store1 `shouldReturn` Just Thing { stuff = 2 }
                           Context.mineMay store2 `shouldReturn` Just 'b'
-                    Monad.void $ Context.forkFinally checkStores \_eResult -> do
+                    Monad.void $ Context.forkFinally checkStores $ \_eResult -> do
                       checkStores
                       Context.putMVar threadDone ()
         Context.takeMVar threadDone
-      it "non-empty stores" do
+      it "non-empty stores" $ do
         threadDone <- Context.newEmptyMVar
-        Context.withNonEmptyStore Thing { stuff = 1 } \store1 -> do
-          Context.withNonEmptyStore 'a' \store2 -> do
+        Context.withNonEmptyStore Thing { stuff = 1 } $ \store1 -> do
+          Context.withNonEmptyStore 'a' $ \store2 -> do
             let checkStores = do
                   Context.mineMay store1 `shouldReturn` Just Thing { stuff = 1 }
                   Context.mineMay store2 `shouldReturn` Just 'a'
-            Monad.void $ Context.forkFinally checkStores \_eResult -> do
+            Monad.void $ Context.forkFinally checkStores $ \_eResult -> do
               checkStores
               Context.putMVar threadDone ()
         Context.takeMVar threadDone
 
-  describe "forkIOWithUnmask" do
-    describe "mineMay" do
-      it "empty stores" do
+  describe "forkIOWithUnmask" $ do
+    describe "mineMay" $ do
+      it "empty stores" $ do
         threadDone <- Context.newEmptyMVar
-        Context.withEmptyStore @IO @Thing \store1 -> do
-          Context.withEmptyStore @IO @Char \store2 -> do
-            Monad.void $ Context.forkIOWithUnmask \_restore -> do
+        Context.withEmptyStore @IO @Thing $ \store1 -> do
+          Context.withEmptyStore @IO @Char $ \store2 -> do
+            Monad.void $ Context.forkIOWithUnmask $ \_restore -> do
               Context.mineMay store1 `shouldReturn` Nothing
               Context.mineMay store2 `shouldReturn` Nothing
               Context.putMVar threadDone ()
         Context.takeMVar threadDone
-      it "initially-empty stores with registered context" do
+      it "initially-empty stores with registered context" $ do
         threadDone <- Context.newEmptyMVar
-        Context.withEmptyStore \store1 -> do
-          Context.use store1 Thing { stuff = 1 } do
-            Context.withEmptyStore \store2 -> do
-              Context.use store2 'a' do
-                Monad.void $ Context.forkIOWithUnmask \_restore -> do
+        Context.withEmptyStore $ \store1 -> do
+          Context.use store1 Thing { stuff = 1 } $ do
+            Context.withEmptyStore $ \store2 -> do
+              Context.use store2 'a' $ do
+                Monad.void $ Context.forkIOWithUnmask $ \_restore -> do
                   Context.mineMay store1 `shouldReturn` Just Thing { stuff = 1 }
                   Context.mineMay store2 `shouldReturn` Just 'a'
                   Context.putMVar threadDone ()
         Context.takeMVar threadDone
-      it "initially-empty stores with nested contexts" do
+      it "initially-empty stores with nested contexts" $ do
         threadDone <- Context.newEmptyMVar
-        Context.withEmptyStore \store1 -> do
-          Context.use store1 Thing { stuff = 1 } do
-            Context.use store1 Thing { stuff = 2 } do
-              Context.withEmptyStore \store2 -> do
-                Context.use store2 'a' do
-                  Context.use store2 'b' do
-                    Monad.void $ Context.forkIOWithUnmask \_restore -> do
+        Context.withEmptyStore $ \store1 -> do
+          Context.use store1 Thing { stuff = 1 } $ do
+            Context.use store1 Thing { stuff = 2 } $ do
+              Context.withEmptyStore $ \store2 -> do
+                Context.use store2 'a' $ do
+                  Context.use store2 'b' $ do
+                    Monad.void $ Context.forkIOWithUnmask $ \_restore -> do
                       Context.mineMay store1 `shouldReturn` Just Thing { stuff = 2 }
                       Context.mineMay store2 `shouldReturn` Just 'b'
                       Context.putMVar threadDone ()
         Context.takeMVar threadDone
-      it "non-empty stores" do
+      it "non-empty stores" $ do
         threadDone <- Context.newEmptyMVar
-        Context.withNonEmptyStore Thing { stuff = 1 } \store1 -> do
-          Context.withNonEmptyStore 'a' \store2 -> do
-            Monad.void $ Context.forkIOWithUnmask \_restore -> do
+        Context.withNonEmptyStore Thing { stuff = 1 } $ \store1 -> do
+          Context.withNonEmptyStore 'a' $ \store2 -> do
+            Monad.void $ Context.forkIOWithUnmask $ \_restore -> do
               Context.mineMay store1 `shouldReturn` Just Thing { stuff = 1 }
               Context.mineMay store2 `shouldReturn` Just 'a'
               Context.putMVar threadDone ()
         Context.takeMVar threadDone
 
-  describe "forkOn" do
-    describe "mineMay" do
-      it "empty stores" do
+  describe "forkOn" $ do
+    describe "mineMay" $ do
+      it "empty stores" $ do
         threadDone <- Context.newEmptyMVar
-        Context.withEmptyStore @IO @Thing \store1 -> do
-          Context.withEmptyStore @IO @Char \store2 -> do
-            Monad.void $ Context.forkOn 1 do
+        Context.withEmptyStore @IO @Thing $ \store1 -> do
+          Context.withEmptyStore @IO @Char $ \store2 -> do
+            Monad.void $ Context.forkOn 1 $ do
               Context.mineMay store1 `shouldReturn` Nothing
               Context.mineMay store2 `shouldReturn` Nothing
               Context.putMVar threadDone ()
         Context.takeMVar threadDone
-      it "initially-empty stores with registered context" do
+      it "initially-empty stores with registered context" $ do
         threadDone <- Context.newEmptyMVar
-        Context.withEmptyStore \store1 -> do
-          Context.use store1 Thing { stuff = 1 } do
-            Context.withEmptyStore \store2 -> do
-              Context.use store2 'a' do
-                Monad.void $ Context.forkOn 1 do
+        Context.withEmptyStore $ \store1 -> do
+          Context.use store1 Thing { stuff = 1 } $ do
+            Context.withEmptyStore $ \store2 -> do
+              Context.use store2 'a' $ do
+                Monad.void $ Context.forkOn 1 $ do
                   Context.mineMay store1 `shouldReturn` Just Thing { stuff = 1 }
                   Context.mineMay store2 `shouldReturn` Just 'a'
                   Context.putMVar threadDone ()
         Context.takeMVar threadDone
-      it "initially-empty stores with nested contexts" do
+      it "initially-empty stores with nested contexts" $ do
         threadDone <- Context.newEmptyMVar
-        Context.withEmptyStore \store1 -> do
-          Context.use store1 Thing { stuff = 1 } do
-            Context.use store1 Thing { stuff = 2 } do
-              Context.withEmptyStore \store2 -> do
-                Context.use store2 'a' do
-                  Context.use store2 'b' do
-                    Monad.void $ Context.forkOn 1 do
+        Context.withEmptyStore $ \store1 -> do
+          Context.use store1 Thing { stuff = 1 } $ do
+            Context.use store1 Thing { stuff = 2 } $ do
+              Context.withEmptyStore $ \store2 -> do
+                Context.use store2 'a' $ do
+                  Context.use store2 'b' $ do
+                    Monad.void $ Context.forkOn 1 $ do
                       Context.mineMay store1 `shouldReturn` Just Thing { stuff = 2 }
                       Context.mineMay store2 `shouldReturn` Just 'b'
                       Context.putMVar threadDone ()
         Context.takeMVar threadDone
-      it "non-empty stores" do
+      it "non-empty stores" $ do
         threadDone <- Context.newEmptyMVar
-        Context.withNonEmptyStore Thing { stuff = 1 } \store1 -> do
-          Context.withNonEmptyStore 'a' \store2 -> do
-            Monad.void $ Context.forkOn 1 do
+        Context.withNonEmptyStore Thing { stuff = 1 } $ \store1 -> do
+          Context.withNonEmptyStore 'a' $ \store2 -> do
+            Monad.void $ Context.forkOn 1 $ do
               Context.mineMay store1 `shouldReturn` Just Thing { stuff = 1 }
               Context.mineMay store2 `shouldReturn` Just 'a'
               Context.putMVar threadDone ()
         Context.takeMVar threadDone
 
-  describe "forkOnWithUnmask" do
-    describe "mineMay" do
-      it "empty stores" do
+  describe "forkOnWithUnmask" $ do
+    describe "mineMay" $ do
+      it "empty stores" $ do
         threadDone <- Context.newEmptyMVar
-        Context.withEmptyStore @IO @Thing \store1 -> do
-          Context.withEmptyStore @IO @Char \store2 -> do
-            Monad.void $ Context.forkOnWithUnmask 1 \_restore -> do
+        Context.withEmptyStore @IO @Thing $ \store1 -> do
+          Context.withEmptyStore @IO @Char $ \store2 -> do
+            Monad.void $ Context.forkOnWithUnmask 1 $ \_restore -> do
               Context.mineMay store1 `shouldReturn` Nothing
               Context.mineMay store2 `shouldReturn` Nothing
               Context.putMVar threadDone ()
         Context.takeMVar threadDone
-      it "initially-empty stores with registered context" do
+      it "initially-empty stores with registered context" $ do
         threadDone <- Context.newEmptyMVar
-        Context.withEmptyStore \store1 -> do
-          Context.use store1 Thing { stuff = 1 } do
-            Context.withEmptyStore \store2 -> do
-              Context.use store2 'a' do
-                Monad.void $ Context.forkOnWithUnmask 1 \_restore -> do
+        Context.withEmptyStore $ \store1 -> do
+          Context.use store1 Thing { stuff = 1 } $ do
+            Context.withEmptyStore $ \store2 -> do
+              Context.use store2 'a' $ do
+                Monad.void $ Context.forkOnWithUnmask 1 $ \_restore -> do
                   Context.mineMay store1 `shouldReturn` Just Thing { stuff = 1 }
                   Context.mineMay store2 `shouldReturn` Just 'a'
                   Context.putMVar threadDone ()
         Context.takeMVar threadDone
-      it "initially-empty stores with nested contexts" do
+      it "initially-empty stores with nested contexts" $ do
         threadDone <- Context.newEmptyMVar
-        Context.withEmptyStore \store1 -> do
-          Context.use store1 Thing { stuff = 1 } do
-            Context.use store1 Thing { stuff = 2 } do
-              Context.withEmptyStore \store2 -> do
-                Context.use store2 'a' do
-                  Context.use store2 'b' do
-                    Monad.void $ Context.forkOnWithUnmask 1 \_restore -> do
+        Context.withEmptyStore $ \store1 -> do
+          Context.use store1 Thing { stuff = 1 } $ do
+            Context.use store1 Thing { stuff = 2 } $ do
+              Context.withEmptyStore $ \store2 -> do
+                Context.use store2 'a' $ do
+                  Context.use store2 'b' $ do
+                    Monad.void $ Context.forkOnWithUnmask 1 $ \_restore -> do
                       Context.mineMay store1 `shouldReturn` Just Thing { stuff = 2 }
                       Context.mineMay store2 `shouldReturn` Just 'b'
                       Context.putMVar threadDone ()
         Context.takeMVar threadDone
-      it "non-empty stores" do
+      it "non-empty stores" $ do
         threadDone <- Context.newEmptyMVar
-        Context.withNonEmptyStore Thing { stuff = 1 } \store1 -> do
-          Context.withNonEmptyStore 'a' \store2 -> do
-            Monad.void $ Context.forkOnWithUnmask 1 \_restore -> do
+        Context.withNonEmptyStore Thing { stuff = 1 } $ \store1 -> do
+          Context.withNonEmptyStore 'a' $ \store2 -> do
+            Monad.void $ Context.forkOnWithUnmask 1 $ \_restore -> do
               Context.mineMay store1 `shouldReturn` Just Thing { stuff = 1 }
               Context.mineMay store2 `shouldReturn` Just 'a'
               Context.putMVar threadDone ()
         Context.takeMVar threadDone
 
-  describe "forkOS" do
-    describe "mineMay" do
-      it "empty stores" do
+  describe "forkOS" $ do
+    describe "mineMay" $ do
+      it "empty stores" $ do
         threadDone <- Context.newEmptyMVar
-        Context.withEmptyStore @IO @Thing \store1 -> do
-          Context.withEmptyStore @IO @Char \store2 -> do
-            Monad.void $ Context.forkOS do
+        Context.withEmptyStore @IO @Thing $ \store1 -> do
+          Context.withEmptyStore @IO @Char $ \store2 -> do
+            Monad.void $ Context.forkOS $ do
               Context.mineMay store1 `shouldReturn` Nothing
               Context.mineMay store2 `shouldReturn` Nothing
               Context.putMVar threadDone ()
         Context.takeMVar threadDone
-      it "initially-empty stores with registered context" do
+      it "initially-empty stores with registered context" $ do
         threadDone <- Context.newEmptyMVar
-        Context.withEmptyStore \store1 -> do
-          Context.use store1 Thing { stuff = 1 } do
-            Context.withEmptyStore \store2 -> do
-              Context.use store2 'a' do
-                Monad.void $ Context.forkOS do
+        Context.withEmptyStore $ \store1 -> do
+          Context.use store1 Thing { stuff = 1 } $ do
+            Context.withEmptyStore $ \store2 -> do
+              Context.use store2 'a' $ do
+                Monad.void $ Context.forkOS $ do
                   Context.mineMay store1 `shouldReturn` Just Thing { stuff = 1 }
                   Context.mineMay store2 `shouldReturn` Just 'a'
                   Context.putMVar threadDone ()
         Context.takeMVar threadDone
-      it "initially-empty stores with nested contexts" do
+      it "initially-empty stores with nested contexts" $ do
         threadDone <- Context.newEmptyMVar
-        Context.withEmptyStore \store1 -> do
-          Context.use store1 Thing { stuff = 1 } do
-            Context.use store1 Thing { stuff = 2 } do
-              Context.withEmptyStore \store2 -> do
-                Context.use store2 'a' do
-                  Context.use store2 'b' do
-                    Monad.void $ Context.forkOS do
+        Context.withEmptyStore $ \store1 -> do
+          Context.use store1 Thing { stuff = 1 } $ do
+            Context.use store1 Thing { stuff = 2 } $ do
+              Context.withEmptyStore $ \store2 -> do
+                Context.use store2 'a' $ do
+                  Context.use store2 'b' $ do
+                    Monad.void $ Context.forkOS $ do
                       Context.mineMay store1 `shouldReturn` Just Thing { stuff = 2 }
                       Context.mineMay store2 `shouldReturn` Just 'b'
                       Context.putMVar threadDone ()
         Context.takeMVar threadDone
-      it "non-empty stores" do
+      it "non-empty stores" $ do
         threadDone <- Context.newEmptyMVar
-        Context.withNonEmptyStore Thing { stuff = 1 } \store1 -> do
-          Context.withNonEmptyStore 'a' \store2 -> do
-            Monad.void $ Context.forkOS do
+        Context.withNonEmptyStore Thing { stuff = 1 } $ \store1 -> do
+          Context.withNonEmptyStore 'a' $ \store2 -> do
+            Monad.void $ Context.forkOS $ do
               Context.mineMay store1 `shouldReturn` Just Thing { stuff = 1 }
               Context.mineMay store2 `shouldReturn` Just 'a'
               Context.putMVar threadDone ()
         Context.takeMVar threadDone
 
-  describe "forkOSWithUnmask" do
-    describe "mineMay" do
-      it "empty stores" do
+  describe "forkOSWithUnmask" $ do
+    describe "mineMay" $ do
+      it "empty stores" $ do
         threadDone <- Context.newEmptyMVar
-        Context.withEmptyStore @IO @Thing \store1 -> do
-          Context.withEmptyStore @IO @Char \store2 -> do
-            Monad.void $ Context.forkOSWithUnmask \_restore -> do
+        Context.withEmptyStore @IO @Thing $ \store1 -> do
+          Context.withEmptyStore @IO @Char $ \store2 -> do
+            Monad.void $ Context.forkOSWithUnmask $ \_restore -> do
               Context.mineMay store1 `shouldReturn` Nothing
               Context.mineMay store2 `shouldReturn` Nothing
               Context.putMVar threadDone ()
         Context.takeMVar threadDone
-      it "initially-empty stores with registered context" do
+      it "initially-empty stores with registered context" $ do
         threadDone <- Context.newEmptyMVar
-        Context.withEmptyStore \store1 -> do
-          Context.use store1 Thing { stuff = 1 } do
-            Context.withEmptyStore \store2 -> do
-              Context.use store2 'a' do
-                Monad.void $ Context.forkOSWithUnmask \_restore -> do
+        Context.withEmptyStore $ \store1 -> do
+          Context.use store1 Thing { stuff = 1 } $ do
+            Context.withEmptyStore $ \store2 -> do
+              Context.use store2 'a' $ do
+                Monad.void $ Context.forkOSWithUnmask $ \_restore -> do
                   Context.mineMay store1 `shouldReturn` Just Thing { stuff = 1 }
                   Context.mineMay store2 `shouldReturn` Just 'a'
                   Context.putMVar threadDone ()
         Context.takeMVar threadDone
-      it "initially-empty stores with nested contexts" do
+      it "initially-empty stores with nested contexts" $ do
         threadDone <- Context.newEmptyMVar
-        Context.withEmptyStore \store1 -> do
-          Context.use store1 Thing { stuff = 1 } do
-            Context.use store1 Thing { stuff = 2 } do
-              Context.withEmptyStore \store2 -> do
-                Context.use store2 'a' do
-                  Context.use store2 'b' do
-                    Monad.void $ Context.forkOSWithUnmask \_restore -> do
+        Context.withEmptyStore $ \store1 -> do
+          Context.use store1 Thing { stuff = 1 } $ do
+            Context.use store1 Thing { stuff = 2 } $ do
+              Context.withEmptyStore $ \store2 -> do
+                Context.use store2 'a' $ do
+                  Context.use store2 'b' $ do
+                    Monad.void $ Context.forkOSWithUnmask $ \_restore -> do
                       Context.mineMay store1 `shouldReturn` Just Thing { stuff = 2 }
                       Context.mineMay store2 `shouldReturn` Just 'b'
                       Context.putMVar threadDone ()
         Context.takeMVar threadDone
-      it "non-empty stores" do
+      it "non-empty stores" $ do
         threadDone <- Context.newEmptyMVar
-        Context.withNonEmptyStore Thing { stuff = 1 } \store1 -> do
-          Context.withNonEmptyStore 'a' \store2 -> do
-            Monad.void $ Context.forkOSWithUnmask \_restore -> do
+        Context.withNonEmptyStore Thing { stuff = 1 } $ \store1 -> do
+          Context.withNonEmptyStore 'a' $ \store2 -> do
+            Monad.void $ Context.forkOSWithUnmask $ \_restore -> do
               Context.mineMay store1 `shouldReturn` Just Thing { stuff = 1 }
               Context.mineMay store2 `shouldReturn` Just 'a'
               Context.putMVar threadDone ()
         Context.takeMVar threadDone
 
-  describe "runInBoundThread" do
-    describe "mineMay" do
-      it "empty stores" do
+  describe "runInBoundThread" $ do
+    describe "mineMay" $ do
+      it "empty stores" $ do
         threadDone <- Context.newEmptyMVar
-        Context.withEmptyStore @IO @Thing \store1 -> do
-          Context.withEmptyStore @IO @Char \store2 -> do
-            Context.runInBoundThread do
+        Context.withEmptyStore @IO @Thing $ \store1 -> do
+          Context.withEmptyStore @IO @Char $ \store2 -> do
+            Context.runInBoundThread $ do
               Context.mineMay store1 `shouldReturn` Nothing
               Context.mineMay store2 `shouldReturn` Nothing
               Context.putMVar threadDone ()
         Context.takeMVar threadDone
-      it "initially-empty stores with registered context" do
+      it "initially-empty stores with registered context" $ do
         threadDone <- Context.newEmptyMVar
-        Context.withEmptyStore \store1 -> do
-          Context.use store1 Thing { stuff = 1 } do
-            Context.withEmptyStore \store2 -> do
-              Context.use store2 'a' do
-                Context.runInBoundThread do
+        Context.withEmptyStore $ \store1 -> do
+          Context.use store1 Thing { stuff = 1 } $ do
+            Context.withEmptyStore $ \store2 -> do
+              Context.use store2 'a' $ do
+                Context.runInBoundThread $ do
                   Context.mineMay store1 `shouldReturn` Just Thing { stuff = 1 }
                   Context.mineMay store2 `shouldReturn` Just 'a'
                   Context.putMVar threadDone ()
         Context.takeMVar threadDone
-      it "initially-empty stores with nested contexts" do
+      it "initially-empty stores with nested contexts" $ do
         threadDone <- Context.newEmptyMVar
-        Context.withEmptyStore \store1 -> do
-          Context.use store1 Thing { stuff = 1 } do
-            Context.use store1 Thing { stuff = 2 } do
-              Context.withEmptyStore \store2 -> do
-                Context.use store2 'a' do
-                  Context.use store2 'b' do
-                    Context.runInBoundThread do
+        Context.withEmptyStore $ \store1 -> do
+          Context.use store1 Thing { stuff = 1 } $ do
+            Context.use store1 Thing { stuff = 2 } $ do
+              Context.withEmptyStore $ \store2 -> do
+                Context.use store2 'a' $ do
+                  Context.use store2 'b' $ do
+                    Context.runInBoundThread $ do
                       Context.mineMay store1 `shouldReturn` Just Thing { stuff = 2 }
                       Context.mineMay store2 `shouldReturn` Just 'b'
                       Context.putMVar threadDone ()
         Context.takeMVar threadDone
-      it "non-empty stores" do
+      it "non-empty stores" $ do
         threadDone <- Context.newEmptyMVar
-        Context.withNonEmptyStore Thing { stuff = 1 } \store1 -> do
-          Context.withNonEmptyStore 'a' \store2 -> do
-            Context.runInBoundThread do
+        Context.withNonEmptyStore Thing { stuff = 1 } $ \store1 -> do
+          Context.withNonEmptyStore 'a' $ \store2 -> do
+            Context.runInBoundThread $ do
               Context.mineMay store1 `shouldReturn` Just Thing { stuff = 1 }
               Context.mineMay store2 `shouldReturn` Just 'a'
               Context.putMVar threadDone ()
         Context.takeMVar threadDone
 
-  describe "runInUnboundThread" do
-    describe "mineMay" do
-      it "empty stores" do
+  describe "runInUnboundThread" $ do
+    describe "mineMay" $ do
+      it "empty stores" $ do
         threadDone <- Context.newEmptyMVar
-        Context.withEmptyStore @IO @Thing \store1 -> do
-          Context.withEmptyStore @IO @Char \store2 -> do
-            Context.runInUnboundThread do
+        Context.withEmptyStore @IO @Thing $ \store1 -> do
+          Context.withEmptyStore @IO @Char $ \store2 -> do
+            Context.runInUnboundThread $ do
               Context.mineMay store1 `shouldReturn` Nothing
               Context.mineMay store2 `shouldReturn` Nothing
               Context.putMVar threadDone ()
         Context.takeMVar threadDone
-      it "initially-empty stores with registered context" do
+      it "initially-empty stores with registered context" $ do
         threadDone <- Context.newEmptyMVar
-        Context.withEmptyStore \store1 -> do
-          Context.use store1 Thing { stuff = 1 } do
-            Context.withEmptyStore \store2 -> do
-              Context.use store2 'a' do
-                Context.runInUnboundThread do
+        Context.withEmptyStore $ \store1 -> do
+          Context.use store1 Thing { stuff = 1 } $ do
+            Context.withEmptyStore $ \store2 -> do
+              Context.use store2 'a' $ do
+                Context.runInUnboundThread $ do
                   Context.mineMay store1 `shouldReturn` Just Thing { stuff = 1 }
                   Context.mineMay store2 `shouldReturn` Just 'a'
                   Context.putMVar threadDone ()
         Context.takeMVar threadDone
-      it "initially-empty stores with nested contexts" do
+      it "initially-empty stores with nested contexts" $ do
         threadDone <- Context.newEmptyMVar
-        Context.withEmptyStore \store1 -> do
-          Context.use store1 Thing { stuff = 1 } do
-            Context.use store1 Thing { stuff = 2 } do
-              Context.withEmptyStore \store2 -> do
-                Context.use store2 'a' do
-                  Context.use store2 'b' do
-                    Context.runInUnboundThread do
+        Context.withEmptyStore $ \store1 -> do
+          Context.use store1 Thing { stuff = 1 } $ do
+            Context.use store1 Thing { stuff = 2 } $ do
+              Context.withEmptyStore $ \store2 -> do
+                Context.use store2 'a' $ do
+                  Context.use store2 'b' $ do
+                    Context.runInUnboundThread $ do
                       Context.mineMay store1 `shouldReturn` Just Thing { stuff = 2 }
                       Context.mineMay store2 `shouldReturn` Just 'b'
                       Context.putMVar threadDone ()
         Context.takeMVar threadDone
-      it "non-empty stores" do
+      it "non-empty stores" $ do
         threadDone <- Context.newEmptyMVar
-        Context.withNonEmptyStore Thing { stuff = 1 } \store1 -> do
-          Context.withNonEmptyStore 'a' \store2 -> do
-            Context.runInUnboundThread do
+        Context.withNonEmptyStore Thing { stuff = 1 } $ \store1 -> do
+          Context.withNonEmptyStore 'a' $ \store2 -> do
+            Context.runInUnboundThread $ do
               Context.mineMay store1 `shouldReturn` Just Thing { stuff = 1 }
               Context.mineMay store2 `shouldReturn` Just 'a'
               Context.putMVar threadDone ()

--- a/context/test-suite/Test/Context/ImplicitSpec.hs
+++ b/context/test-suite/Test/Context/ImplicitSpec.hs
@@ -1,6 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -36,204 +35,204 @@ instance IP "contextStore" (Store Thing) where
 
 spec :: Spec
 spec = do
-  describe "emptyStore" do
-    describe "mineMay" do
-      it "empty" do
+  describe "emptyStore" $ do
+    describe "mineMay" $ do
+      it "empty" $ do
         Context.mineMay `shouldReturn` Nothing
-      it "single context" do
-        Context.use Thing { stuff = 1 } do
+      it "single context" $ do
+        Context.use Thing { stuff = 1 } $ do
           Context.mineMay `shouldReturn` Just Thing { stuff = 1 }
         Context.mineMay `shouldReturn` Nothing
-      it "nested contexts" do
-        Context.use Thing { stuff = 1 } do
+      it "nested contexts" $ do
+        Context.use Thing { stuff = 1 } $ do
           Context.mineMay `shouldReturn` Just Thing { stuff = 1 }
-          Context.use Thing { stuff = 2 } do
+          Context.use Thing { stuff = 2 } $ do
             Context.mineMay `shouldReturn` Just Thing { stuff = 2 }
-            Context.use Thing { stuff = 3 } do
+            Context.use Thing { stuff = 3 } $ do
               Context.mineMay `shouldReturn` Just Thing { stuff = 3 }
             Context.mineMay `shouldReturn` Just Thing { stuff = 2 }
-          Context.use Thing { stuff = 4 } do
+          Context.use Thing { stuff = 4 } $ do
             Context.mineMay `shouldReturn` Just Thing { stuff = 4 }
           Context.mineMay `shouldReturn` Just Thing { stuff = 1 }
         Context.mineMay `shouldReturn` Nothing
-      it "concurrent nested contexts" do
+      it "concurrent nested contexts" $ do
         let mkContext i = Thing { stuff = i }
-        Async.forConcurrently_ [1 :: Int ..10] $ const do
+        Async.forConcurrently_ [1 :: Int ..10] $ const $ do
           Context.mineMay `shouldReturn` Nothing
-          Context.use (mkContext 1) do
+          Context.use (mkContext 1) $ do
             Context.mineMay `shouldReturn` Just (mkContext 1)
-            Context.use (mkContext 2) do
+            Context.use (mkContext 2) $ do
               Context.mineMay `shouldReturn` Just (mkContext 2)
-              Context.use (mkContext 3) do
+              Context.use (mkContext 3) $ do
                 Context.mineMay `shouldReturn` Just (mkContext 3)
               Context.mineMay `shouldReturn` Just (mkContext 2)
-            Context.use (mkContext 4) do
+            Context.use (mkContext 4) $ do
               Context.mineMay `shouldReturn` Just (mkContext 4)
             Context.mineMay `shouldReturn` Just (mkContext 1)
           Context.mineMay `shouldReturn` Nothing
         Context.mineMay `shouldReturn` Nothing
 
-    describe "minesMay" do
-      it "empty" do
+    describe "minesMay" $ do
+      it "empty" $ do
         Context.minesMay stuff `shouldReturn` Nothing
-      it "single context" do
-        Context.use Thing { stuff = 1 } do
+      it "single context" $ do
+        Context.use Thing { stuff = 1 } $ do
           Context.minesMay stuff `shouldReturn` Just 1
         Context.minesMay stuff `shouldReturn` Nothing
-      it "nested contexts" do
-        Context.use Thing { stuff = 1 } do
+      it "nested contexts" $ do
+        Context.use Thing { stuff = 1 } $ do
           Context.minesMay stuff `shouldReturn` Just 1
-          Context.use Thing { stuff = 2 } do
+          Context.use Thing { stuff = 2 } $ do
             Context.minesMay stuff `shouldReturn` Just 2
-            Context.use Thing { stuff = 3 } do
+            Context.use Thing { stuff = 3 } $ do
               Context.minesMay stuff `shouldReturn` Just 3
             Context.minesMay stuff `shouldReturn` Just 2
-          Context.use Thing { stuff = 4 } do
+          Context.use Thing { stuff = 4 } $ do
             Context.minesMay stuff `shouldReturn` Just 4
           Context.minesMay stuff `shouldReturn` Just 1
         Context.minesMay stuff `shouldReturn` Nothing
-      it "concurrent nested contexts" do
+      it "concurrent nested contexts" $ do
         let mkContext i = Thing { stuff = i }
-        Async.forConcurrently_ [1 :: Int ..10] $ const do
+        Async.forConcurrently_ [1 :: Int ..10] $ const $ do
           Context.minesMay stuff `shouldReturn` Nothing
-          Context.use (mkContext 1) do
+          Context.use (mkContext 1) $ do
             Context.minesMay stuff `shouldReturn` Just 1
-            Context.use (mkContext 2) do
+            Context.use (mkContext 2) $ do
               Context.minesMay stuff `shouldReturn` Just 2
-              Context.use (mkContext 3) do
+              Context.use (mkContext 3) $ do
                 Context.minesMay stuff `shouldReturn` Just 3
               Context.minesMay stuff `shouldReturn` Just 2
-            Context.use (mkContext 4) do
+            Context.use (mkContext 4) $ do
               Context.minesMay stuff `shouldReturn` Just 4
             Context.minesMay stuff `shouldReturn` Just 1
           Context.minesMay stuff `shouldReturn` Nothing
         Context.minesMay stuff `shouldReturn` Nothing
 
-    describe "mine" do
-      it "empty" do
+    describe "mine" $ do
+      it "empty" $ do
         threadId <- Concurrent.myThreadId
         Context.mine `shouldThrow` notFound threadId
-      it "single context" do
+      it "single context" $ do
         threadId <- Concurrent.myThreadId
-        Context.use Thing { stuff = 1 } do
+        Context.use Thing { stuff = 1 } $ do
           Context.mine `shouldReturn` Thing { stuff = 1 }
         Context.mine `shouldThrow` notFound threadId
-      it "nested contexts" do
+      it "nested contexts" $ do
         threadId <- Concurrent.myThreadId
-        Context.use Thing { stuff = 1 } do
+        Context.use Thing { stuff = 1 } $ do
           Context.mine `shouldReturn` Thing { stuff = 1 }
-          Context.use Thing { stuff = 2 } do
+          Context.use Thing { stuff = 2 } $ do
             Context.mine `shouldReturn` Thing { stuff = 2 }
-            Context.use Thing { stuff = 3 } do
+            Context.use Thing { stuff = 3 } $ do
               Context.mine `shouldReturn` Thing { stuff = 3 }
             Context.mine `shouldReturn` Thing { stuff = 2 }
-          Context.use Thing { stuff = 4 } do
+          Context.use Thing { stuff = 4 } $ do
             Context.mine `shouldReturn` Thing { stuff = 4 }
           Context.mine `shouldReturn` Thing { stuff = 1 }
         Context.mine `shouldThrow` notFound threadId
-      it "concurrent nested contexts" do
+      it "concurrent nested contexts" $ do
         let mkContext i = Thing { stuff = i }
         initThreadId <- Concurrent.myThreadId
-        Async.forConcurrently_ [1 :: Int ..10] $ const do
+        Async.forConcurrently_ [1 :: Int ..10] $ const $ do
           threadId <- Concurrent.myThreadId
           Context.mine `shouldThrow` notFound threadId
-          Context.use (mkContext 1) do
+          Context.use (mkContext 1) $ do
             Context.mine `shouldReturn` mkContext 1
-            Context.use (mkContext 2) do
+            Context.use (mkContext 2) $ do
               Context.mine `shouldReturn` mkContext 2
-              Context.use (mkContext 3) do
+              Context.use (mkContext 3) $ do
                 Context.mine `shouldReturn` mkContext 3
               Context.mine `shouldReturn` mkContext 2
-            Context.use (mkContext 4) do
+            Context.use (mkContext 4) $ do
               Context.mine `shouldReturn` mkContext 4
             Context.mine `shouldReturn` mkContext 1
           Context.mine `shouldThrow` notFound threadId
         Context.mine `shouldThrow` notFound initThreadId
 
-    describe "mines" do
-      it "empty" do
+    describe "mines" $ do
+      it "empty" $ do
         threadId <- Concurrent.myThreadId
         Context.mines stuff `shouldThrow` notFound threadId
-      it "single context" do
+      it "single context" $ do
         threadId <- Concurrent.myThreadId
-        Context.use Thing { stuff = 1 } do
+        Context.use Thing { stuff = 1 } $ do
           Context.mines stuff `shouldReturn` 1
         Context.mines stuff `shouldThrow` notFound threadId
-      it "nested contexts" do
+      it "nested contexts" $ do
         threadId <- Concurrent.myThreadId
-        Context.use Thing { stuff = 1 } do
+        Context.use Thing { stuff = 1 } $ do
           Context.mines stuff `shouldReturn` 1
-          Context.use Thing { stuff = 2 } do
+          Context.use Thing { stuff = 2 } $ do
             Context.mines stuff `shouldReturn` 2
-            Context.use Thing { stuff = 3 } do
+            Context.use Thing { stuff = 3 } $ do
               Context.mines stuff `shouldReturn` 3
             Context.mines stuff `shouldReturn` 2
-          Context.use Thing { stuff = 4 } do
+          Context.use Thing { stuff = 4 } $ do
             Context.mines stuff `shouldReturn` 4
           Context.mines stuff `shouldReturn` 1
         Context.mines stuff `shouldThrow` notFound threadId
-      it "concurrent nested contexts" do
+      it "concurrent nested contexts" $ do
         let mkContext i = Thing { stuff = i }
         initThreadId <- Concurrent.myThreadId
-        Async.forConcurrently_ [1 :: Int ..10] $ const do
+        Async.forConcurrently_ [1 :: Int ..10] $ const $ do
           threadId <- Concurrent.myThreadId
           Context.mine `shouldThrow` notFound threadId
-          Context.use (mkContext 1) do
+          Context.use (mkContext 1) $ do
             Context.mines stuff `shouldReturn` 1
-            Context.use (mkContext 2) do
+            Context.use (mkContext 2) $ do
               Context.mines stuff `shouldReturn` 2
-              Context.use (mkContext 3) do
+              Context.use (mkContext 3) $ do
                 Context.mines stuff `shouldReturn` 3
               Context.mines stuff `shouldReturn` 2
-            Context.use (mkContext 4) do
+            Context.use (mkContext 4) $ do
               Context.mines stuff `shouldReturn` 4
             Context.mines stuff `shouldReturn` 1
           Context.mines stuff `shouldThrow` notFound threadId
         Context.mines stuff `shouldThrow` notFound initThreadId
 
-    describe "adjust" do
-      it "empty" do
+    describe "adjust" $ do
+      it "empty" $ do
         threadId <- Concurrent.myThreadId
         Context.adjust modifier (error "does not get here")
           `shouldThrow` notFound threadId
-      it "single context" do
+      it "single context" $ do
         threadId <- Concurrent.myThreadId
-        Context.use Thing { stuff = 1 } do
+        Context.use Thing { stuff = 1 } $ do
           Context.mine `shouldReturn` Thing { stuff = 1 }
-          Context.adjust modifier do
+          Context.adjust modifier $ do
             Context.mine `shouldReturn` Thing { stuff = 2 }
           Context.mine `shouldReturn` Thing { stuff = 1 }
         Context.mine `shouldThrow` notFound threadId
-      it "nested contexts" do
+      it "nested contexts" $ do
         threadId <- Concurrent.myThreadId
-        Context.use Thing { stuff = 1 } do
-          Context.adjust modifier do
+        Context.use Thing { stuff = 1 } $ do
+          Context.adjust modifier $ do
             Context.mine `shouldReturn` Thing { stuff = 2 }
-            Context.use Thing { stuff = 3 } do
+            Context.use Thing { stuff = 3 } $ do
               Context.mine `shouldReturn` Thing { stuff = 3 }
-              Context.use Thing { stuff = 4 } do
+              Context.use Thing { stuff = 4 } $ do
                 Context.mine `shouldReturn` Thing { stuff = 4 }
               Context.mine `shouldReturn` Thing { stuff = 3 }
-            Context.use Thing { stuff = 4 } do
+            Context.use Thing { stuff = 4 } $ do
               Context.mine `shouldReturn` Thing { stuff = 4 }
             Context.mine `shouldReturn` Thing { stuff = 2 }
           Context.mine `shouldReturn` Thing { stuff = 1 }
         Context.mine `shouldThrow` notFound threadId
-      it "concurrent nested contexts" do
+      it "concurrent nested contexts" $ do
         let mkContext i = Thing { stuff = i }
         initThreadId <- Concurrent.myThreadId
-        Async.forConcurrently_ [1 :: Int ..10] $ const do
+        Async.forConcurrently_ [1 :: Int ..10] $ const $ do
           threadId <- Concurrent.myThreadId
           Context.mine `shouldThrow` notFound threadId
-          Context.use (mkContext 1) do
-            Context.adjust modifier do
+          Context.use (mkContext 1) $ do
+            Context.adjust modifier $ do
               Context.mine `shouldReturn` mkContext 2
-              Context.use (mkContext 3) do
+              Context.use (mkContext 3) $ do
                 Context.mine `shouldReturn` mkContext 3
-                Context.use (mkContext 4) do
+                Context.use (mkContext 4) $ do
                   Context.mine `shouldReturn` mkContext 4
                 Context.mine `shouldReturn` mkContext 3
-              Context.use (mkContext 5) do
+              Context.use (mkContext 5) $ do
                 Context.mine `shouldReturn` mkContext 5
               Context.mine `shouldReturn` mkContext 2
             Context.mine `shouldReturn` mkContext 1

--- a/context/test-suite/Test/ContextSpec.hs
+++ b/context/test-suite/Test/ContextSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NoImplicitPrelude #-}
@@ -25,544 +24,544 @@ data OtherThing = OtherThing
 
 spec :: Spec
 spec = do
-  describe "withEmptyStore" do
-    describe "mineMay" do
-      it "empty" do
-        Context.withEmptyStore @IO @Thing \store -> do
+  describe "withEmptyStore" $ do
+    describe "mineMay" $ do
+      it "empty" $ do
+        Context.withEmptyStore @IO @Thing $ \store -> do
           Context.mineMay store `shouldReturn` Nothing
-      it "single context" do
-        Context.withEmptyStore @IO @Thing \store -> do
-          Context.use store Thing { stuff = 1 } do
+      it "single context" $ do
+        Context.withEmptyStore @IO @Thing $ \store -> do
+          Context.use store Thing { stuff = 1 } $ do
             Context.mineMay store `shouldReturn` Just Thing { stuff = 1 }
           Context.mineMay store `shouldReturn` Nothing
-      it "nested contexts" do
-        Context.withEmptyStore @IO @Thing \store -> do
-          Context.use store Thing { stuff = 1 } do
+      it "nested contexts" $ do
+        Context.withEmptyStore @IO @Thing $ \store -> do
+          Context.use store Thing { stuff = 1 } $ do
             Context.mineMay store `shouldReturn` Just Thing { stuff = 1 }
-            Context.use store Thing { stuff = 2 } do
+            Context.use store Thing { stuff = 2 } $ do
               Context.mineMay store `shouldReturn` Just Thing { stuff = 2 }
-              Context.use store Thing { stuff = 3 } do
+              Context.use store Thing { stuff = 3 } $ do
                 Context.mineMay store `shouldReturn` Just Thing { stuff = 3 }
               Context.mineMay store `shouldReturn` Just Thing { stuff = 2 }
-            Context.use store Thing { stuff = 4 } do
+            Context.use store Thing { stuff = 4 } $ do
               Context.mineMay store `shouldReturn` Just Thing { stuff = 4 }
             Context.mineMay store `shouldReturn` Just Thing { stuff = 1 }
           Context.mineMay store `shouldReturn` Nothing
-      it "concurrent nested contexts" do
+      it "concurrent nested contexts" $ do
         let mkContext i = Thing { stuff = i }
-        Context.withEmptyStore @IO @Thing \store -> do
-          Async.forConcurrently_ [1 :: Int ..10] $ const do
+        Context.withEmptyStore @IO @Thing $ \store -> do
+          Async.forConcurrently_ [1 :: Int ..10] $ const $ do
             Context.mineMay store `shouldReturn` Nothing
-            Context.use store (mkContext 1) do
+            Context.use store (mkContext 1) $ do
               Context.mineMay store `shouldReturn` Just (mkContext 1)
-              Context.use store (mkContext 2) do
+              Context.use store (mkContext 2) $ do
                 Context.mineMay store `shouldReturn` Just (mkContext 2)
-                Context.use store (mkContext 3) do
+                Context.use store (mkContext 3) $ do
                   Context.mineMay store `shouldReturn` Just (mkContext 3)
                 Context.mineMay store `shouldReturn` Just (mkContext 2)
-              Context.use store (mkContext 4) do
+              Context.use store (mkContext 4) $ do
                 Context.mineMay store `shouldReturn` Just (mkContext 4)
               Context.mineMay store `shouldReturn` Just (mkContext 1)
             Context.mineMay store `shouldReturn` Nothing
           Context.mineMay store `shouldReturn` Nothing
 
-    describe "minesMay" do
-      it "empty" do
-        Context.withEmptyStore @IO @Thing \store -> do
+    describe "minesMay" $ do
+      it "empty" $ do
+        Context.withEmptyStore @IO @Thing $ \store -> do
           Context.minesMay store stuff `shouldReturn` Nothing
-      it "single context" do
-        Context.withEmptyStore @IO @Thing \store -> do
-          Context.use store Thing { stuff = 1 } do
+      it "single context" $ do
+        Context.withEmptyStore @IO @Thing $ \store -> do
+          Context.use store Thing { stuff = 1 } $ do
             Context.minesMay store stuff `shouldReturn` Just 1
           Context.minesMay store stuff `shouldReturn` Nothing
-      it "nested contexts" do
-        Context.withEmptyStore @IO @Thing \store -> do
-          Context.use store Thing { stuff = 1 } do
+      it "nested contexts" $ do
+        Context.withEmptyStore @IO @Thing $ \store -> do
+          Context.use store Thing { stuff = 1 } $ do
             Context.minesMay store stuff `shouldReturn` Just 1
-            Context.use store Thing { stuff = 2 } do
+            Context.use store Thing { stuff = 2 } $ do
               Context.minesMay store stuff `shouldReturn` Just 2
-              Context.use store Thing { stuff = 3 } do
+              Context.use store Thing { stuff = 3 } $ do
                 Context.minesMay store stuff `shouldReturn` Just 3
               Context.minesMay store stuff `shouldReturn` Just 2
-            Context.use store Thing { stuff = 4 } do
+            Context.use store Thing { stuff = 4 } $ do
               Context.minesMay store stuff `shouldReturn` Just 4
             Context.minesMay store stuff `shouldReturn` Just 1
           Context.minesMay store stuff `shouldReturn` Nothing
-      it "concurrent nested contexts" do
+      it "concurrent nested contexts" $ do
         let mkContext i = Thing { stuff = i }
-        Context.withEmptyStore @IO @Thing \store -> do
-          Async.forConcurrently_ [1 :: Int ..10] $ const do
+        Context.withEmptyStore @IO @Thing $ \store -> do
+          Async.forConcurrently_ [1 :: Int ..10] $ const $ do
             Context.minesMay store stuff `shouldReturn` Nothing
-            Context.use store (mkContext 1) do
+            Context.use store (mkContext 1) $ do
               Context.minesMay store stuff `shouldReturn` Just 1
-              Context.use store (mkContext 2) do
+              Context.use store (mkContext 2) $ do
                 Context.minesMay store stuff `shouldReturn` Just 2
-                Context.use store (mkContext 3) do
+                Context.use store (mkContext 3) $ do
                   Context.minesMay store stuff `shouldReturn` Just 3
                 Context.minesMay store stuff `shouldReturn` Just 2
-              Context.use store (mkContext 4) do
+              Context.use store (mkContext 4) $ do
                 Context.minesMay store stuff `shouldReturn` Just 4
               Context.minesMay store stuff `shouldReturn` Just 1
             Context.minesMay store stuff `shouldReturn` Nothing
           Context.minesMay store stuff `shouldReturn` Nothing
 
-    describe "mine" do
-      it "empty" do
-        Context.withEmptyStore @IO @Thing \store -> do
+    describe "mine" $ do
+      it "empty" $ do
+        Context.withEmptyStore @IO @Thing $ \store -> do
           threadId <- Concurrent.myThreadId
           Context.mine store `shouldThrow` notFound threadId
-      it "single context" do
-        Context.withEmptyStore @IO @Thing \store -> do
+      it "single context" $ do
+        Context.withEmptyStore @IO @Thing $ \store -> do
           threadId <- Concurrent.myThreadId
-          Context.use store Thing { stuff = 1 } do
+          Context.use store Thing { stuff = 1 } $ do
             Context.mine store `shouldReturn` Thing { stuff = 1 }
           Context.mine store `shouldThrow` notFound threadId
-      it "nested contexts" do
-        Context.withEmptyStore @IO @Thing \store -> do
+      it "nested contexts" $ do
+        Context.withEmptyStore @IO @Thing $ \store -> do
           threadId <- Concurrent.myThreadId
-          Context.use store Thing { stuff = 1 } do
+          Context.use store Thing { stuff = 1 } $ do
             Context.mine store `shouldReturn` Thing { stuff = 1 }
-            Context.use store Thing { stuff = 2 } do
+            Context.use store Thing { stuff = 2 } $ do
               Context.mine store `shouldReturn` Thing { stuff = 2 }
-              Context.use store Thing { stuff = 3 } do
+              Context.use store Thing { stuff = 3 } $ do
                 Context.mine store `shouldReturn` Thing { stuff = 3 }
               Context.mine store `shouldReturn` Thing { stuff = 2 }
-            Context.use store Thing { stuff = 4 } do
+            Context.use store Thing { stuff = 4 } $ do
               Context.mine store `shouldReturn` Thing { stuff = 4 }
             Context.mine store `shouldReturn` Thing { stuff = 1 }
           Context.mine store `shouldThrow` notFound threadId
-      it "concurrent nested contexts" do
+      it "concurrent nested contexts" $ do
         let mkContext i = Thing { stuff = i }
         initThreadId <- Concurrent.myThreadId
-        Context.withEmptyStore @IO @Thing \store -> do
-          Async.forConcurrently_ [1 :: Int ..10] $ const do
+        Context.withEmptyStore @IO @Thing $ \store -> do
+          Async.forConcurrently_ [1 :: Int ..10] $ const $ do
             threadId <- Concurrent.myThreadId
             Context.mine store `shouldThrow` notFound threadId
-            Context.use store (mkContext 1) do
+            Context.use store (mkContext 1) $ do
               Context.mine store `shouldReturn` mkContext 1
-              Context.use store (mkContext 2) do
+              Context.use store (mkContext 2) $ do
                 Context.mine store `shouldReturn` mkContext 2
-                Context.use store (mkContext 3) do
+                Context.use store (mkContext 3) $ do
                   Context.mine store `shouldReturn` mkContext 3
                 Context.mine store `shouldReturn` mkContext 2
-              Context.use store (mkContext 4) do
+              Context.use store (mkContext 4) $ do
                 Context.mine store `shouldReturn` mkContext 4
               Context.mine store `shouldReturn` mkContext 1
             Context.mine store `shouldThrow` notFound threadId
           Context.mine store `shouldThrow` notFound initThreadId
 
-    describe "mines" do
-      it "empty" do
-        Context.withEmptyStore @IO @Thing \store -> do
+    describe "mines" $ do
+      it "empty" $ do
+        Context.withEmptyStore @IO @Thing $ \store -> do
           threadId <- Concurrent.myThreadId
           Context.mines store stuff `shouldThrow` notFound threadId
-      it "single context" do
-        Context.withEmptyStore @IO @Thing \store -> do
+      it "single context" $ do
+        Context.withEmptyStore @IO @Thing $ \store -> do
           threadId <- Concurrent.myThreadId
-          Context.use store Thing { stuff = 1 } do
+          Context.use store Thing { stuff = 1 } $ do
             Context.mines store stuff `shouldReturn` 1
           Context.mines store stuff `shouldThrow` notFound threadId
-      it "nested contexts" do
-        Context.withEmptyStore @IO @Thing \store -> do
+      it "nested contexts" $ do
+        Context.withEmptyStore @IO @Thing $ \store -> do
           threadId <- Concurrent.myThreadId
-          Context.use store Thing { stuff = 1 } do
+          Context.use store Thing { stuff = 1 } $ do
             Context.mines store stuff `shouldReturn` 1
-            Context.use store Thing { stuff = 2 } do
+            Context.use store Thing { stuff = 2 } $ do
               Context.mines store stuff `shouldReturn` 2
-              Context.use store Thing { stuff = 3 } do
+              Context.use store Thing { stuff = 3 } $ do
                 Context.mines store stuff `shouldReturn` 3
               Context.mines store stuff `shouldReturn` 2
-            Context.use store Thing { stuff = 4 } do
+            Context.use store Thing { stuff = 4 } $ do
               Context.mines store stuff `shouldReturn` 4
             Context.mines store stuff `shouldReturn` 1
           Context.mines store stuff `shouldThrow` notFound threadId
-      it "concurrent nested contexts" do
+      it "concurrent nested contexts" $ do
         let mkContext i = Thing { stuff = i }
         initThreadId <- Concurrent.myThreadId
-        Context.withEmptyStore @IO @Thing \store -> do
-          Async.forConcurrently_ [1 :: Int ..10] $ const do
+        Context.withEmptyStore @IO @Thing $ \store -> do
+          Async.forConcurrently_ [1 :: Int ..10] $ const $ do
             threadId <- Concurrent.myThreadId
             Context.mine store `shouldThrow` notFound threadId
-            Context.use store (mkContext 1) do
+            Context.use store (mkContext 1) $ do
               Context.mines store stuff `shouldReturn` 1
-              Context.use store (mkContext 2) do
+              Context.use store (mkContext 2) $ do
                 Context.mines store stuff `shouldReturn` 2
-                Context.use store (mkContext 3) do
+                Context.use store (mkContext 3) $ do
                   Context.mines store stuff `shouldReturn` 3
                 Context.mines store stuff `shouldReturn` 2
-              Context.use store (mkContext 4) do
+              Context.use store (mkContext 4) $ do
                 Context.mines store stuff `shouldReturn` 4
               Context.mines store stuff `shouldReturn` 1
             Context.mines store stuff `shouldThrow` notFound threadId
           Context.mines store stuff `shouldThrow` notFound initThreadId
 
-    describe "adjust" do
-      it "empty" do
-        Context.withEmptyStore @IO @Thing \store -> do
+    describe "adjust" $ do
+      it "empty" $ do
+        Context.withEmptyStore @IO @Thing $ \store -> do
           threadId <- Concurrent.myThreadId
           Context.adjust store modifier (error "does not get here")
             `shouldThrow` notFound threadId
-      it "single context" do
-        Context.withEmptyStore @IO @Thing \store -> do
+      it "single context" $ do
+        Context.withEmptyStore @IO @Thing $ \store -> do
           threadId <- Concurrent.myThreadId
-          Context.use store Thing { stuff = 1 } do
+          Context.use store Thing { stuff = 1 } $ do
             Context.mine store `shouldReturn` Thing { stuff = 1 }
-            Context.adjust store modifier do
+            Context.adjust store modifier $ do
               Context.mine store `shouldReturn` Thing { stuff = 2 }
             Context.mine store `shouldReturn` Thing { stuff = 1 }
           Context.mine store `shouldThrow` notFound threadId
-      it "nested contexts" do
-        Context.withEmptyStore @IO @Thing \store -> do
+      it "nested contexts" $ do
+        Context.withEmptyStore @IO @Thing $ \store -> do
           threadId <- Concurrent.myThreadId
-          Context.use store Thing { stuff = 1 } do
-            Context.adjust store modifier do
+          Context.use store Thing { stuff = 1 } $ do
+            Context.adjust store modifier $ do
               Context.mine store `shouldReturn` Thing { stuff = 2 }
-              Context.use store Thing { stuff = 3 } do
+              Context.use store Thing { stuff = 3 } $ do
                 Context.mine store `shouldReturn` Thing { stuff = 3 }
-                Context.use store Thing { stuff = 4 } do
+                Context.use store Thing { stuff = 4 } $ do
                   Context.mine store `shouldReturn` Thing { stuff = 4 }
                 Context.mine store `shouldReturn` Thing { stuff = 3 }
-              Context.use store Thing { stuff = 4 } do
+              Context.use store Thing { stuff = 4 } $ do
                 Context.mine store `shouldReturn` Thing { stuff = 4 }
               Context.mine store `shouldReturn` Thing { stuff = 2 }
             Context.mine store `shouldReturn` Thing { stuff = 1 }
           Context.mine store `shouldThrow` notFound threadId
-      it "concurrent nested contexts" do
+      it "concurrent nested contexts" $ do
         let mkContext i = Thing { stuff = i }
         initThreadId <- Concurrent.myThreadId
-        Context.withEmptyStore @IO @Thing \store -> do
-          Async.forConcurrently_ [1 :: Int ..10] $ const do
+        Context.withEmptyStore @IO @Thing $ \store -> do
+          Async.forConcurrently_ [1 :: Int ..10] $ const $ do
             threadId <- Concurrent.myThreadId
             Context.mine store `shouldThrow` notFound threadId
-            Context.use store (mkContext 1) do
-              Context.adjust store modifier do
+            Context.use store (mkContext 1) $ do
+              Context.adjust store modifier $ do
                 Context.mine store `shouldReturn` mkContext 2
-                Context.use store (mkContext 3) do
+                Context.use store (mkContext 3) $ do
                   Context.mine store `shouldReturn` mkContext 3
-                  Context.use store (mkContext 4) do
+                  Context.use store (mkContext 4) $ do
                     Context.mine store `shouldReturn` mkContext 4
                   Context.mine store `shouldReturn` mkContext 3
-                Context.use store (mkContext 5) do
+                Context.use store (mkContext 5) $ do
                   Context.mine store `shouldReturn` mkContext 5
                 Context.mine store `shouldReturn` mkContext 2
               Context.mine store `shouldReturn` mkContext 1
             Context.mine store `shouldThrow` notFound threadId
           Context.mine store `shouldThrow` notFound initThreadId
 
-    describe "setDefault" do
-      it "setting default converts store to non-empty" do
-        Context.withEmptyStore @IO @Thing \store -> do
+    describe "setDefault" $ do
+      it "setting default converts store to non-empty" $ do
+        Context.withEmptyStore @IO @Thing $ \store -> do
           Context.mineMay store `shouldReturn` Nothing
           Context.setDefault store Thing { stuff = 1 }
           Context.mineMay store `shouldReturn` Just Thing { stuff = 1 }
           Context.setDefault store Thing { stuff = 2 }
           Context.mineMay store `shouldReturn` Just Thing { stuff = 2 }
 
-  describe "withNonEmptyStore" do
-    describe "mineMay" do
-      it "default" do
-        Context.withNonEmptyStore Thing { stuff = 0 } \store -> do
+  describe "withNonEmptyStore" $ do
+    describe "mineMay" $ do
+      it "default" $ do
+        Context.withNonEmptyStore Thing { stuff = 0 } $ \store -> do
           Context.mineMay store `shouldReturn` Just Thing { stuff = 0 }
-      it "single context" do
-        Context.withNonEmptyStore Thing { stuff = 0 } \store -> do
-          Context.use store Thing { stuff = 1 } do
+      it "single context" $ do
+        Context.withNonEmptyStore Thing { stuff = 0 } $ \store -> do
+          Context.use store Thing { stuff = 1 } $ do
             Context.mineMay store `shouldReturn` Just Thing { stuff = 1 }
           Context.mineMay store `shouldReturn` Just Thing { stuff = 0 }
-      it "nested contexts" do
-        Context.withNonEmptyStore Thing { stuff = 0 } \store -> do
-          Context.use store Thing { stuff = 1 } do
+      it "nested contexts" $ do
+        Context.withNonEmptyStore Thing { stuff = 0 } $ \store -> do
+          Context.use store Thing { stuff = 1 } $ do
             Context.mineMay store `shouldReturn` Just Thing { stuff = 1 }
-            Context.use store Thing { stuff = 2 } do
+            Context.use store Thing { stuff = 2 } $ do
               Context.mineMay store `shouldReturn` Just Thing { stuff = 2 }
-              Context.use store Thing { stuff = 3 } do
+              Context.use store Thing { stuff = 3 } $ do
                 Context.mineMay store `shouldReturn` Just Thing { stuff = 3 }
               Context.mineMay store `shouldReturn` Just Thing { stuff = 2 }
-            Context.use store Thing { stuff = 4 } do
+            Context.use store Thing { stuff = 4 } $ do
               Context.mineMay store `shouldReturn` Just Thing { stuff = 4 }
             Context.mineMay store `shouldReturn` Just Thing { stuff = 1 }
           Context.mineMay store `shouldReturn` Just Thing { stuff = 0 }
-      it "concurrent nested contexts" do
+      it "concurrent nested contexts" $ do
         let mkContext i = Thing { stuff = i }
-        Context.withNonEmptyStore (mkContext 0) \store -> do
-          Async.forConcurrently_ [1 :: Int ..10] $ const do
+        Context.withNonEmptyStore (mkContext 0) $ \store -> do
+          Async.forConcurrently_ [1 :: Int ..10] $ const $ do
             Context.mineMay store `shouldReturn` Just (mkContext 0)
-            Context.use store (mkContext 1) do
+            Context.use store (mkContext 1) $ do
               Context.mineMay store `shouldReturn` Just (mkContext 1)
-              Context.use store (mkContext 2) do
+              Context.use store (mkContext 2) $ do
                 Context.mineMay store `shouldReturn` Just (mkContext 2)
-                Context.use store (mkContext 3) do
+                Context.use store (mkContext 3) $ do
                   Context.mineMay store `shouldReturn` Just (mkContext 3)
                 Context.mineMay store `shouldReturn` Just (mkContext 2)
-              Context.use store (mkContext 4) do
+              Context.use store (mkContext 4) $ do
                 Context.mineMay store `shouldReturn` Just (mkContext 4)
               Context.mineMay store `shouldReturn` Just (mkContext 1)
             Context.mineMay store `shouldReturn` Just (mkContext 0)
           Context.mineMay store `shouldReturn` Just (mkContext 0)
 
-    describe "minesMay" do
-      it "default" do
-        Context.withNonEmptyStore Thing { stuff = 0 } \store -> do
+    describe "minesMay" $ do
+      it "default" $ do
+        Context.withNonEmptyStore Thing { stuff = 0 } $ \store -> do
           Context.minesMay store stuff `shouldReturn` Just 0
-      it "single context" do
-        Context.withNonEmptyStore Thing { stuff = 0 } \store -> do
-          Context.use store Thing { stuff = 1 } do
+      it "single context" $ do
+        Context.withNonEmptyStore Thing { stuff = 0 } $ \store -> do
+          Context.use store Thing { stuff = 1 } $ do
             Context.minesMay store stuff `shouldReturn` Just 1
           Context.minesMay store stuff `shouldReturn` Just 0
-      it "nested contexts" do
-        Context.withNonEmptyStore Thing { stuff = 0 } \store -> do
-          Context.use store Thing { stuff = 1 } do
+      it "nested contexts" $ do
+        Context.withNonEmptyStore Thing { stuff = 0 } $ \store -> do
+          Context.use store Thing { stuff = 1 } $ do
             Context.minesMay store stuff `shouldReturn` Just 1
-            Context.use store Thing { stuff = 2 } do
+            Context.use store Thing { stuff = 2 } $ do
               Context.minesMay store stuff `shouldReturn` Just 2
-              Context.use store Thing { stuff = 3 } do
+              Context.use store Thing { stuff = 3 } $ do
                 Context.minesMay store stuff `shouldReturn` Just 3
               Context.minesMay store stuff `shouldReturn` Just 2
-            Context.use store Thing { stuff = 4 } do
+            Context.use store Thing { stuff = 4 } $ do
               Context.minesMay store stuff `shouldReturn` Just 4
             Context.minesMay store stuff `shouldReturn` Just 1
           Context.minesMay store stuff `shouldReturn` Just 0
-      it "concurrent nested contexts" do
+      it "concurrent nested contexts" $ do
         let mkContext i = Thing { stuff = i }
-        Context.withNonEmptyStore (mkContext 0) \store -> do
-          Async.forConcurrently_ [1 :: Int ..10] $ const do
+        Context.withNonEmptyStore (mkContext 0) $ \store -> do
+          Async.forConcurrently_ [1 :: Int ..10] $ const $ do
             Context.minesMay store stuff `shouldReturn` Just 0
-            Context.use store (mkContext 1) do
+            Context.use store (mkContext 1) $ do
               Context.minesMay store stuff `shouldReturn` Just 1
-              Context.use store (mkContext 2) do
+              Context.use store (mkContext 2) $ do
                 Context.minesMay store stuff `shouldReturn` Just 2
-                Context.use store (mkContext 3) do
+                Context.use store (mkContext 3) $ do
                   Context.minesMay store stuff `shouldReturn` Just 3
                 Context.minesMay store stuff `shouldReturn` Just 2
-              Context.use store (mkContext 4) do
+              Context.use store (mkContext 4) $ do
                 Context.minesMay store stuff `shouldReturn` Just 4
               Context.minesMay store stuff `shouldReturn` Just 1
             Context.minesMay store stuff `shouldReturn` Just 0
           Context.minesMay store stuff `shouldReturn` Just 0
 
-    describe "mine" do
-      it "default" do
-        Context.withNonEmptyStore Thing { stuff = 0 } \store -> do
+    describe "mine" $ do
+      it "default" $ do
+        Context.withNonEmptyStore Thing { stuff = 0 } $ \store -> do
           Context.mine store `shouldReturn` Thing { stuff = 0 }
-      it "single context" do
-        Context.withNonEmptyStore Thing { stuff = 0 } \store -> do
-          Context.use store Thing { stuff = 1 } do
+      it "single context" $ do
+        Context.withNonEmptyStore Thing { stuff = 0 } $ \store -> do
+          Context.use store Thing { stuff = 1 } $ do
             Context.mine store `shouldReturn` Thing { stuff = 1 }
           Context.mine store `shouldReturn` Thing { stuff = 0 }
-      it "nested contexts" do
-        Context.withNonEmptyStore Thing { stuff = 0 } \store -> do
-          Context.use store Thing { stuff = 1 } do
+      it "nested contexts" $ do
+        Context.withNonEmptyStore Thing { stuff = 0 } $ \store -> do
+          Context.use store Thing { stuff = 1 } $ do
             Context.mine store `shouldReturn` Thing { stuff = 1 }
-            Context.use store Thing { stuff = 2 } do
+            Context.use store Thing { stuff = 2 } $ do
               Context.mine store `shouldReturn` Thing { stuff = 2 }
-              Context.use store Thing { stuff = 3 } do
+              Context.use store Thing { stuff = 3 } $ do
                 Context.mine store `shouldReturn` Thing { stuff = 3 }
               Context.mine store `shouldReturn` Thing { stuff = 2 }
-            Context.use store Thing { stuff = 4 } do
+            Context.use store Thing { stuff = 4 } $ do
               Context.mine store `shouldReturn` Thing { stuff = 4 }
             Context.mine store `shouldReturn` Thing { stuff = 1 }
           Context.mine store `shouldReturn` Thing { stuff = 0 }
-      it "concurrent nested contexts" do
+      it "concurrent nested contexts" $ do
         let mkContext i = Thing { stuff = i }
-        Context.withNonEmptyStore (mkContext 0) \store -> do
-          Async.forConcurrently_ [1 :: Int ..10] $ const do
+        Context.withNonEmptyStore (mkContext 0) $ \store -> do
+          Async.forConcurrently_ [1 :: Int ..10] $ const $ do
             Context.mine store `shouldReturn` mkContext 0
-            Context.use store (mkContext 1) do
+            Context.use store (mkContext 1) $ do
               Context.mine store `shouldReturn` mkContext 1
-              Context.use store (mkContext 2) do
+              Context.use store (mkContext 2) $ do
                 Context.mine store `shouldReturn` mkContext 2
-                Context.use store (mkContext 3) do
+                Context.use store (mkContext 3) $ do
                   Context.mine store `shouldReturn` mkContext 3
                 Context.mine store `shouldReturn` mkContext 2
-              Context.use store (mkContext 4) do
+              Context.use store (mkContext 4) $ do
                 Context.mine store `shouldReturn` mkContext 4
               Context.mine store `shouldReturn` mkContext 1
             Context.mine store `shouldReturn` mkContext 0
           Context.mine store `shouldReturn` mkContext 0
 
-    describe "mines" do
-      it "default" do
-        Context.withNonEmptyStore Thing { stuff = 0 } \store -> do
+    describe "mines" $ do
+      it "default" $ do
+        Context.withNonEmptyStore Thing { stuff = 0 } $ \store -> do
           Context.mines store stuff `shouldReturn` 0
-      it "single context" do
-        Context.withNonEmptyStore Thing { stuff = 0 } \store -> do
-          Context.use store Thing { stuff = 1 } do
+      it "single context" $ do
+        Context.withNonEmptyStore Thing { stuff = 0 } $ \store -> do
+          Context.use store Thing { stuff = 1 } $ do
             Context.mines store stuff `shouldReturn` 1
           Context.mines store stuff `shouldReturn` 0
-      it "nested contexts" do
-        Context.withNonEmptyStore Thing { stuff = 0 } \store -> do
-          Context.use store Thing { stuff = 1 } do
+      it "nested contexts" $ do
+        Context.withNonEmptyStore Thing { stuff = 0 } $ \store -> do
+          Context.use store Thing { stuff = 1 } $ do
             Context.mines store stuff `shouldReturn` 1
-            Context.use store Thing { stuff = 2 } do
+            Context.use store Thing { stuff = 2 } $ do
               Context.mines store stuff `shouldReturn` 2
-              Context.use store Thing { stuff = 3 } do
+              Context.use store Thing { stuff = 3 } $ do
                 Context.mines store stuff `shouldReturn` 3
               Context.mines store stuff `shouldReturn` 2
-            Context.use store Thing { stuff = 4 } do
+            Context.use store Thing { stuff = 4 } $ do
               Context.mines store stuff `shouldReturn` 4
             Context.mines store stuff `shouldReturn` 1
           Context.mines store stuff `shouldReturn` 0
-      it "concurrent nested contexts" do
+      it "concurrent nested contexts" $ do
         let mkContext i = Thing { stuff = i }
-        Context.withNonEmptyStore (mkContext 0) \store -> do
-          Async.forConcurrently_ [1 :: Int ..10] $ const do
+        Context.withNonEmptyStore (mkContext 0) $ \store -> do
+          Async.forConcurrently_ [1 :: Int ..10] $ const $ do
             Context.mines store stuff `shouldReturn` 0
-            Context.use store (mkContext 1) do
+            Context.use store (mkContext 1) $ do
               Context.mines store stuff `shouldReturn` 1
-              Context.use store (mkContext 2) do
+              Context.use store (mkContext 2) $ do
                 Context.mines store stuff `shouldReturn` 2
-                Context.use store (mkContext 3) do
+                Context.use store (mkContext 3) $ do
                   Context.mines store stuff `shouldReturn` 3
                 Context.mines store stuff `shouldReturn` 2
-              Context.use store (mkContext 4) do
+              Context.use store (mkContext 4) $ do
                 Context.mines store stuff `shouldReturn` 4
               Context.mines store stuff `shouldReturn` 1
             Context.mines store stuff `shouldReturn` 0
           Context.mines store stuff `shouldReturn` 0
 
-    describe "adjust" do
-      it "default" do
-        Context.withNonEmptyStore Thing { stuff = 1 } \store -> do
-          Context.adjust store modifier do
+    describe "adjust" $ do
+      it "default" $ do
+        Context.withNonEmptyStore Thing { stuff = 1 } $ \store -> do
+          Context.adjust store modifier $ do
             Context.mine store `shouldReturn` Thing { stuff = 2 }
           Context.mine store `shouldReturn` Thing { stuff = 1 }
-      it "single context" do
-        Context.withNonEmptyStore Thing { stuff = 0 } \store -> do
-          Context.use store Thing { stuff = 1 } do
+      it "single context" $ do
+        Context.withNonEmptyStore Thing { stuff = 0 } $ \store -> do
+          Context.use store Thing { stuff = 1 } $ do
             Context.mine store `shouldReturn` Thing { stuff = 1 }
-            Context.adjust store modifier do
+            Context.adjust store modifier $ do
               Context.mine store `shouldReturn` Thing { stuff = 2 }
             Context.mine store `shouldReturn` Thing { stuff = 1 }
           Context.mine store `shouldReturn` Thing { stuff = 0 }
-      it "nested contexts" do
-        Context.withNonEmptyStore Thing { stuff = 0 } \store -> do
-          Context.use store Thing { stuff = 1 } do
-            Context.adjust store modifier do
+      it "nested contexts" $ do
+        Context.withNonEmptyStore Thing { stuff = 0 } $ \store -> do
+          Context.use store Thing { stuff = 1 } $ do
+            Context.adjust store modifier $ do
               Context.mine store `shouldReturn` Thing { stuff = 2 }
-              Context.use store Thing { stuff = 3 } do
+              Context.use store Thing { stuff = 3 } $ do
                 Context.mine store `shouldReturn` Thing { stuff = 3 }
-                Context.use store Thing { stuff = 4 } do
+                Context.use store Thing { stuff = 4 } $ do
                   Context.mine store `shouldReturn` Thing { stuff = 4 }
                 Context.mine store `shouldReturn` Thing { stuff = 3 }
-              Context.use store Thing { stuff = 4 } do
+              Context.use store Thing { stuff = 4 } $ do
                 Context.mine store `shouldReturn` Thing { stuff = 4 }
               Context.mine store `shouldReturn` Thing { stuff = 2 }
             Context.mine store `shouldReturn` Thing { stuff = 1 }
           Context.mine store `shouldReturn` Thing { stuff = 0 }
-      it "concurrent nested contexts" do
+      it "concurrent nested contexts" $ do
         let mkContext i = Thing { stuff = i }
-        Context.withNonEmptyStore (mkContext 0) \store -> do
-          Async.forConcurrently_ [1 :: Int ..10] $ const do
+        Context.withNonEmptyStore (mkContext 0) $ \store -> do
+          Async.forConcurrently_ [1 :: Int ..10] $ const $ do
             Context.mine store `shouldReturn` mkContext 0
-            Context.use store (mkContext 1) do
-              Context.adjust store modifier do
+            Context.use store (mkContext 1) $ do
+              Context.adjust store modifier $ do
                 Context.mine store `shouldReturn` mkContext 2
-                Context.use store (mkContext 3) do
+                Context.use store (mkContext 3) $ do
                   Context.mine store `shouldReturn` mkContext 3
-                  Context.use store (mkContext 4) do
+                  Context.use store (mkContext 4) $ do
                     Context.mine store `shouldReturn` mkContext 4
                   Context.mine store `shouldReturn` mkContext 3
-                Context.use store (mkContext 5) do
+                Context.use store (mkContext 5) $ do
                   Context.mine store `shouldReturn` mkContext 5
                 Context.mine store `shouldReturn` mkContext 2
               Context.mine store `shouldReturn` mkContext 1
             Context.mine store `shouldReturn` mkContext 0
           Context.mine store `shouldReturn` mkContext 0
 
-    describe "setDefault" do
-      it "setting default overrides initial default" do
-        Context.withNonEmptyStore Thing { stuff = 1 } \store -> do
+    describe "setDefault" $ do
+      it "setting default overrides initial default" $ do
+        Context.withNonEmptyStore Thing { stuff = 1 } $ \store -> do
           Context.mineMay store `shouldReturn` Just Thing { stuff = 1 }
           Context.setDefault store Thing { stuff = 2 }
           Context.mineMay store `shouldReturn` Just Thing { stuff = 2 }
 
-    describe "viewMay" do
-      it "empty" do
-        Context.withEmptyStore @IO @Thing \store -> do
+    describe "viewMay" $ do
+      it "empty" $ do
+        Context.withEmptyStore @IO @Thing $ \store -> do
           let storeView = fmap toOtherThing $ Context.toView store
           Context.viewMay storeView `shouldReturn` Nothing
-      it "single context" do
-        Context.withEmptyStore @IO @Thing \store -> do
+      it "single context" $ do
+        Context.withEmptyStore @IO @Thing $ \store -> do
           let storeView = fmap toOtherThing $ Context.toView store
-          Context.use store Thing { stuff = 1 } do
+          Context.use store Thing { stuff = 1 } $ do
             Context.viewMay storeView `shouldReturn` Just OtherThing { otherStuff = 1 }
           Context.viewMay storeView `shouldReturn` Nothing
-      it "nested contexts" do
-        Context.withEmptyStore @IO @Thing \store -> do
+      it "nested contexts" $ do
+        Context.withEmptyStore @IO @Thing $ \store -> do
           let storeView = fmap toOtherThing $ Context.toView store
-          Context.use store Thing { stuff = 1 } do
+          Context.use store Thing { stuff = 1 } $ do
             Context.viewMay storeView `shouldReturn` Just OtherThing { otherStuff = 1 }
-            Context.use store Thing { stuff = 2 } do
+            Context.use store Thing { stuff = 2 } $ do
               Context.viewMay storeView `shouldReturn` Just OtherThing { otherStuff = 2 }
-              Context.use store Thing { stuff = 3 } do
+              Context.use store Thing { stuff = 3 } $ do
                 Context.viewMay storeView `shouldReturn` Just OtherThing { otherStuff = 3 }
               Context.viewMay storeView `shouldReturn` Just OtherThing { otherStuff = 2 }
-            Context.use store Thing { stuff = 4 } do
+            Context.use store Thing { stuff = 4 } $ do
               Context.viewMay storeView `shouldReturn` Just OtherThing { otherStuff = 4 }
             Context.viewMay storeView `shouldReturn` Just OtherThing { otherStuff = 1 }
           Context.viewMay storeView `shouldReturn` Nothing
-      it "concurrent nested contexts" do
+      it "concurrent nested contexts" $ do
         let mkContext i = Thing { stuff = i }
-        Context.withEmptyStore @IO @Thing \store -> do
+        Context.withEmptyStore @IO @Thing $ \store -> do
           let storeView = fmap toOtherThing $ Context.toView store
-          Async.forConcurrently_ [1 :: Int ..10] $ const do
+          Async.forConcurrently_ [1 :: Int ..10] $ const $ do
             Context.viewMay storeView `shouldReturn` Nothing
-            Context.use store (mkContext 1) do
+            Context.use store (mkContext 1) $ do
               Context.viewMay storeView `shouldReturn` Just (toOtherThing $ mkContext 1)
-              Context.use store (mkContext 2) do
+              Context.use store (mkContext 2) $ do
                 Context.viewMay storeView `shouldReturn` Just (toOtherThing $ mkContext 2)
-                Context.use store (mkContext 3) do
+                Context.use store (mkContext 3) $ do
                   Context.viewMay storeView `shouldReturn` Just (toOtherThing $ mkContext 3)
                 Context.viewMay storeView `shouldReturn` Just (toOtherThing $ mkContext 2)
-              Context.use store (mkContext 4) do
+              Context.use store (mkContext 4) $ do
                 Context.viewMay storeView `shouldReturn` Just (toOtherThing $ mkContext 4)
               Context.viewMay storeView `shouldReturn` Just (toOtherThing $ mkContext 1)
             Context.viewMay storeView `shouldReturn` Nothing
           Context.viewMay storeView `shouldReturn` Nothing
 
-    describe "view" do
-      it "empty" do
-        Context.withEmptyStore @IO @Thing \store -> do
+    describe "view" $ do
+      it "empty" $ do
+        Context.withEmptyStore @IO @Thing $ \store -> do
           let storeView = fmap toOtherThing $ Context.toView store
           threadId <- Concurrent.myThreadId
           Context.view storeView `shouldThrow` notFound threadId
-      it "single context" do
-        Context.withEmptyStore @IO @Thing \store -> do
+      it "single context" $ do
+        Context.withEmptyStore @IO @Thing $ \store -> do
           let storeView = fmap toOtherThing $ Context.toView store
           threadId <- Concurrent.myThreadId
-          Context.use store Thing { stuff = 1 } do
+          Context.use store Thing { stuff = 1 } $ do
             Context.view storeView `shouldReturn` OtherThing { otherStuff = 1 }
           Context.view storeView `shouldThrow` notFound threadId
-      it "nested contexts" do
-        Context.withEmptyStore @IO @Thing \store -> do
+      it "nested contexts" $ do
+        Context.withEmptyStore @IO @Thing $ \store -> do
           let storeView = fmap toOtherThing $ Context.toView store
           threadId <- Concurrent.myThreadId
-          Context.use store Thing { stuff = 1 } do
+          Context.use store Thing { stuff = 1 } $ do
             Context.view storeView `shouldReturn` OtherThing { otherStuff = 1 }
-            Context.use store Thing { stuff = 2 } do
+            Context.use store Thing { stuff = 2 } $ do
               Context.view storeView `shouldReturn` OtherThing { otherStuff = 2 }
-              Context.use store Thing { stuff = 3 } do
+              Context.use store Thing { stuff = 3 } $ do
                 Context.view storeView `shouldReturn` OtherThing { otherStuff = 3 }
               Context.view storeView `shouldReturn` OtherThing { otherStuff = 2 }
-            Context.use store Thing { stuff = 4 } do
+            Context.use store Thing { stuff = 4 } $ do
               Context.view storeView `shouldReturn` OtherThing { otherStuff = 4 }
             Context.view storeView `shouldReturn` OtherThing { otherStuff = 1 }
           Context.view storeView `shouldThrow` notFound threadId
-      it "concurrent nested contexts" do
+      it "concurrent nested contexts" $ do
         let mkContext i = Thing { stuff = i }
         initThreadId <- Concurrent.myThreadId
-        Context.withEmptyStore @IO @Thing \store -> do
+        Context.withEmptyStore @IO @Thing $ \store -> do
           let storeView = fmap toOtherThing $ Context.toView store
-          Async.forConcurrently_ [1 :: Int ..10] $ const do
+          Async.forConcurrently_ [1 :: Int ..10] $ const $ do
             threadId <- Concurrent.myThreadId
             Context.view storeView `shouldThrow` notFound threadId
-            Context.use store (mkContext 1) do
+            Context.use store (mkContext 1) $ do
               Context.view storeView `shouldReturn` (toOtherThing $ mkContext 1)
-              Context.use store (mkContext 2) do
+              Context.use store (mkContext 2) $ do
                 Context.view storeView `shouldReturn` (toOtherThing $ mkContext 2)
-                Context.use store (mkContext 3) do
+                Context.use store (mkContext 3) $ do
                   Context.view storeView `shouldReturn` (toOtherThing $ mkContext 3)
                 Context.view storeView `shouldReturn` (toOtherThing $ mkContext 2)
-              Context.use store (mkContext 4) do
+              Context.use store (mkContext 4) $ do
                 Context.view storeView `shouldReturn` (toOtherThing $ mkContext 4)
               Context.view storeView `shouldReturn` (toOtherThing $ mkContext 1)
             Context.view storeView `shouldThrow` notFound threadId


### PR DESCRIPTION
I'm looking to keep some our of OSS libraries compatible down to GHC 8.4, which now makes use of [things that make use of] `monad-logger-aeson`, which makes use of `context`, which has a `base >= 4.12` bound. Phew.

The only required change was to not use `BlockArguments`. Would that be OK?

To test this, I temporarily moved `stack.yaml` to `lts-12.26`. Let me know if you'd like me to set up a multi-GHC CI, like you have over in `monad-logger-aeson`.
